### PR TITLE
Only log JSON during debug mode, with a switch

### DIFF
--- a/Odysee.xcodeproj/project.pbxproj
+++ b/Odysee.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		64FF820F2604FB0B009B7A3B /* FirstRunDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64FF820E2604FB0B009B7A3B /* FirstRunDelegate.swift */; };
 		64FF821A260507D2009B7A3B /* CreateChannelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64FF8219260507D2009B7A3B /* CreateChannelViewController.swift */; };
 		B63C54A7260C990C00DD26A9 /* AuthenticationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B63C54A6260C990C00DD26A9 /* AuthenticationServices.framework */; };
+		CC97807926549867009F580E /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC97807826549867009F580E /* Log.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -193,6 +194,7 @@
 		64FF820E2604FB0B009B7A3B /* FirstRunDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstRunDelegate.swift; sourceTree = "<group>"; };
 		64FF8219260507D2009B7A3B /* CreateChannelViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateChannelViewController.swift; sourceTree = "<group>"; };
 		B63C54A6260C990C00DD26A9 /* AuthenticationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AuthenticationServices.framework; path = System/Library/Frameworks/AuthenticationServices.framework; sourceTree = SDKROOT; };
+		CC97807826549867009F580E /* Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -256,6 +258,7 @@
 			children = (
 				641327432556EB2200CBB6B8 /* LbryUri.swift */,
 				641327482556EB3400CBB6B8 /* Lbry.swift */,
+				CC97807826549867009F580E /* Log.swift */,
 				6413274D2557D89200CBB6B8 /* Extensions.swift */,
 				64424DD9255895A500F2D247 /* ContentSources.swift */,
 				644F76B525595D4E00813451 /* Cache.swift */,
@@ -661,6 +664,7 @@
 				641AFAE925B606E000218BD9 /* UAButton.swift in Sources */,
 				641E7EC12608BE0C00A79CD3 /* Language.swift in Sources */,
 				644F76AE25592F8400813451 /* FileViewController.swift in Sources */,
+				CC97807926549867009F580E /* Log.swift in Sources */,
 				64FBE79D25502A290082AF2E /* AppDelegate.swift in Sources */,
 				6413273E2556E86000CBB6B8 /* Claim.swift in Sources */,
 				642B6B0C257AB9F200F17355 /* WalletBalance.swift in Sources */,

--- a/Odysee/Controllers/Library/PublishViewController.swift
+++ b/Odysee/Controllers/Library/PublishViewController.swift
@@ -7,6 +7,7 @@
 
 import MobileCoreServices
 import Firebase
+import os
 import Photos
 import PhotosUI
 import UIKit
@@ -519,10 +520,7 @@ class PublishViewController: UIViewController, UIGestureRecognizerDelegate, UIPi
                         }
                         
                         do {
-                            // TODO: remove
-                            if let JSONString = String(data: data, encoding: String.Encoding.utf8) {
-                               //print(JSONString)
-                            }
+                            os_log(.debug, log: Log.verboseJSON, "\(String(data: data, encoding: .utf8)!)")
                             
                             let response = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
                             if (response?["result"] != nil) {

--- a/Odysee/Utils/Lbry.swift
+++ b/Odysee/Utils/Lbry.swift
@@ -8,6 +8,7 @@
 import Base58Swift
 import CoreData
 import CryptoKit
+import os
 import Foundation
 
 final class Lbry {
@@ -91,10 +92,7 @@ final class Lbry {
                 return
             }
             do {
-                // TODO: remove
-                if let JSONString = String(data: data, encoding: String.Encoding.utf8) {
-                   print(JSONString)
-                }
+                os_log(.debug, log: Log.verboseJSON, "\(String(data: data, encoding: .utf8)!)")
                 
                 let response = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
                 if (response?["result"] != nil) {

--- a/Odysee/Utils/Lbryio.swift
+++ b/Odysee/Utils/Lbryio.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 import Firebase
- 
+import os
+
 final class Lbryio {
     static let methodGet = "GET"
     static let methodPost = "POST"
@@ -105,10 +106,7 @@ final class Lbryio {
                 }
                 let respData = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
                 
-                // TODO: remove
-                if let JSONString = String(data: data, encoding: String.Encoding.utf8) {
-                   //print(JSONString)
-                }
+                os_log(.debug, log: Log.verboseJSON, "\(String(data: data, encoding: .utf8)!)")
                 
                 if (respCode >= 200 && respCode < 300) {
                     if (respData?["data"] == nil) {

--- a/Odysee/Utils/Log.swift
+++ b/Odysee/Utils/Log.swift
@@ -1,0 +1,15 @@
+//
+//  Log.swift
+//  Odysee
+//
+//  Created by Adlai on 5/18/21.
+//
+
+import Foundation
+import os
+
+struct Log {
+    // Uncomment to print all JSON responses in debug mode.
+//    static let verboseJSON = OSLog(subsystem: "com.lbry.odysee", category: "json")
+    static let verboseJSON = OSLog.disabled
+}


### PR DESCRIPTION
Before this change, in release mode all 3 print statements did the work of forming String objects, even in release mode. The print in Lbry.swift also printed the JSON to stdout. It's a lot of work.

After this change, JSON responses are not stringified or printed unless debugging, and unless the specified line is uncommented.

Let me know if the default should be for JSON to be printed during debugging.

The `os_log` call uses special swift magic to avoid even stringifying the arguments if the specified log isn't enabled. See the disassembly:

```
    if (os_log_type_enabled(r0, r20) != 0x0) {
            asm { movn       x1, #0x0 };
            r0 = swift_slowAlloc();
            *(int32_t *)r0 = 0x8000100;
            sub_100003c40(0x100008118);
            r0 = swift_allocObject();
            r8 = *type metadata for Swift.String;
            *(int128_t *)(r0 + 0x10) = *0x100003e00;
            *(r0 + 0x38) = r8;
            *(int128_t *)(r0 + 0x20) = 0x64657461657243;
            *(int128_t *)(r0 + 0x28) = 0xe700000000000000;
            Swift.print();
            swift_release(r22);
            *(r21 + 0x4) = 0x5;
            _os_log_impl(0x100000000, r19, r20, "Testing: %ld", r21, 0xc);
            asm { movn       x1, #0x0 };
            asm { movn       x2, #0x0 };
            swift_slowDealloc();
    }
```

Fixes #122 