### PR TITLE
Use PINRemoteImage to manage remote images

### DIFF
--- a/Odysee.xcodeproj/project.pbxproj
+++ b/Odysee.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		B63C54A7260C990C00DD26A9 /* AuthenticationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B63C54A6260C990C00DD26A9 /* AuthenticationServices.framework */; };
 		CC97807926549867009F580E /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC97807826549867009F580E /* Log.swift */; };
 		CCDDA9172655C1340006035F /* FileDismissAnimationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDDA9162655C1340006035F /* FileDismissAnimationController.swift */; };
+		CCDDA929265861AF0006035F /* PINRemoteImage in Frameworks */ = {isa = PBXBuildFile; productRef = CCDDA928265861AF0006035F /* PINRemoteImage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -211,6 +212,7 @@
 				646D5645258587A8002DB12F /* OAuthSwift in Frameworks */,
 				6411C0B0255B35260018C3D5 /* Base58Swift in Frameworks */,
 				648F70D226307BC700885A2F /* HaishinKit in Frameworks */,
+				CCDDA929265861AF0006035F /* PINRemoteImage in Frameworks */,
 				6484E1B62582269B00221658 /* StoreKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -483,6 +485,7 @@
 				646D5644258587A8002DB12F /* OAuthSwift */,
 				6459121C2620745D00B2ABA5 /* Starscream */,
 				648F70D126307BC700885A2F /* HaishinKit */,
+				CCDDA928265861AF0006035F /* PINRemoteImage */,
 			);
 			productName = Odysee;
 			productReference = 64FBE79925502A290082AF2E /* Odysee.app */;
@@ -561,6 +564,7 @@
 				646D5643258587A8002DB12F /* XCRemoteSwiftPackageReference "OAuthSwift" */,
 				6459121B2620745C00B2ABA5 /* XCRemoteSwiftPackageReference "Starscream" */,
 				648F70D026307BC700885A2F /* XCRemoteSwiftPackageReference "HaishinKit" */,
+				CCDDA927265861AF0006035F /* XCRemoteSwiftPackageReference "PINRemoteImage" */,
 			);
 			productRefGroup = 64FBE79A25502A290082AF2E /* Products */;
 			projectDirPath = "";
@@ -1054,6 +1058,14 @@
 				minimumVersion = 1.1.4;
 			};
 		};
+		CCDDA927265861AF0006035F /* XCRemoteSwiftPackageReference "PINRemoteImage" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pinterest/PINRemoteImage";
+			requirement = {
+				kind = revision;
+				revision = 93428e8b6e797d27d1f57425937c0e094d0f4ad8;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1086,6 +1098,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 648F70D026307BC700885A2F /* XCRemoteSwiftPackageReference "HaishinKit" */;
 			productName = HaishinKit;
+		};
+		CCDDA928265861AF0006035F /* PINRemoteImage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CCDDA927265861AF0006035F /* XCRemoteSwiftPackageReference "PINRemoteImage" */;
+			productName = PINRemoteImage;
 		};
 /* End XCSwiftPackageProductDependency section */
 

--- a/Odysee.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Odysee.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -119,6 +119,15 @@
         }
       },
       {
+        "package": "libwebp",
+        "repositoryURL": "https://github.com/SDWebImage/libwebp-Xcode",
+        "state": {
+          "branch": null,
+          "revision": "289862b9466243cdec407997d4cb8ba529359a99",
+          "version": "1.2.0"
+        }
+      },
+      {
         "package": "Logboard",
         "repositoryURL": "https://github.com/shogo4405/Logboard.git",
         "state": {
@@ -143,6 +152,33 @@
           "branch": null,
           "revision": "fde77955e6983fbfaabd491709d52b8a82fda4d0",
           "version": "2.1.2"
+        }
+      },
+      {
+        "package": "PINCache",
+        "repositoryURL": "https://github.com/pinterest/PINCache.git",
+        "state": {
+          "branch": null,
+          "revision": "875c654984fb52b47ca65ae70d24852b0003ccd9",
+          "version": "3.0.3"
+        }
+      },
+      {
+        "package": "PINOperation",
+        "repositoryURL": "https://github.com/pinterest/PINOperation.git",
+        "state": {
+          "branch": null,
+          "revision": "44d8ca154a4e75a028a5548c31ff3a53b90cef15",
+          "version": "1.2.1"
+        }
+      },
+      {
+        "package": "PINRemoteImage",
+        "repositoryURL": "https://github.com/pinterest/PINRemoteImage",
+        "state": {
+          "branch": null,
+          "revision": "93428e8b6e797d27d1f57425937c0e094d0f4ad8",
+          "version": null
         }
       },
       {

--- a/Odysee/Utils/Cache.swift
+++ b/Odysee/Utils/Cache.swift
@@ -7,13 +7,14 @@
 
 import Foundation
 
+// TODO: Remove in favor of PINRemoteImage.
 class Cache {
     static let imageCache = NSCache<NSString, NSData>()
 
     static func putImage(url: String, image: Data) {
-        imageCache.setObject(image as NSData, forKey: NSString(string: url))
+        imageCache.setObject(image as NSData, forKey: url as NSString)
     }
     static func getImage(url: String) -> Data? {
-        return imageCache.object(forKey: NSString(string: url)) as Data?
+        return imageCache.object(forKey: url as NSString) as Data?
     }
 }

--- a/Odysee/Utils/Extensions.swift
+++ b/Odysee/Utils/Extensions.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import PINRemoteImage
 import UIKit
 
 extension String {
@@ -31,24 +32,7 @@ extension String {
 
 extension UIImageView {
     func load(url: URL) {
-        DispatchQueue.global().async { [weak self] in
-            DispatchQueue.main.async {
-                self?.image = nil
-            }
-            
-            var image: UIImage? = nil
-            if let cacheData = Cache.getImage(url: url.absoluteString) {
-                image = UIImage(data: cacheData)
-            } else if let data = try? Data(contentsOf: url) {
-                image = UIImage(data: data)
-                if (image != nil) {
-                    Cache.putImage(url: url.absoluteString, image: data)
-                }
-            }
-            DispatchQueue.main.async {
-                self?.image = image
-            }
-        }
+        self.pin_setImage(from: url)
     }
     
     func rounded() {


### PR DESCRIPTION
Fixes #130 

PINRemoteImage is a pretty good framework for handling all of the above. It also supports animated images and a disk cache.

Test on my iPhone 11 Pro. Scroll down 4 or 5 pages on home, then scroll back to the top. Notice the main thread time drops from 3 seconds in the "before" trace from the issue, to 2 seconds, with no image decoding on main.

<img width="1858" alt="Screen Shot 2021-05-22 at 7 21 46 AM" src="https://user-images.githubusercontent.com/2466893/119224840-64acaf00-bace-11eb-95ad-1d3c7dd34d80.png">