### PR TITLE
Add a new Lbry.apiCall method with improved API

### DIFF
--- a/Odysee/Utils/Extensions.swift
+++ b/Odysee/Utils/Extensions.swift
@@ -79,7 +79,7 @@ extension URLSession {
                 }
                 guard let data = data, let response = response else {
                     assertionFailure()
-                    throw GenericError("no error but no data and/or no response: '\(data.debugDescription)' '\(response.debugDescription)")
+                    throw GenericError("no error but no data and/or no response")
                 }
                 return DataTaskSuccess(data: data, response: response)
             }


### PR DESCRIPTION
The old version is still there and works the same as before. 

As a followup to #120, I think this is the right path forward for all API calls. I migrated `FileViewController.loadRelatedContent` to the new API to show how it works.

This version of the method has a few benefits:

- We only parse once, ever. So the previous parse-into-dictionary then serialize then parse into Claims is gone.
- No more strings.
- Deliver on the main thread, so that view controllers can use it safely.
- Deliver a `Result<Value, Error>` instead of `([String: Any]?, Error?)` so it's easier to work with.

Are there docs for the server API so I can double-check the error handling logic? Or can you take a look at it @akinwale and see if it's right? Particularly, what does the server return if there's no error and no response? Like "OK".