### PR TITLE
Migrate HomeViewController to new apiCall method

### DIFF
--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -777,7 +777,7 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
                 }
             }
             
-            Lbry.apiCall(method: Lbry.methodResolve,
+            Lbry.apiCall(method: Lbry.Methods.resolve,
                          params: ["urls": resolveUrls],
                          url: Lbry.lbrytvURL,
                          completion: self.handleRelatedContentResult)

--- a/Odysee/Controllers/Content/HomeViewController.swift
+++ b/Odysee/Controllers/Content/HomeViewController.swift
@@ -101,12 +101,12 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
         if case let .success(payload) = result {
             lastPageReached = payload.unfilteredItemCount! < pageSize
             UIView.performWithoutAnimation {
-                claimListView.performBatchUpdates({
+                claimListView.performBatchUpdates {
                     let oldCount = claims.count
                     claims.append(contentsOf: payload.items)
                     let indexPaths = (oldCount..<claims.count).map { IndexPath(item: $0, section: 0) }
                     claimListView.insertRows(at: indexPaths, with: .automatic)
-                }, completion: nil)
+                }
             }
         }
         loadingContainer.isHidden = true

--- a/Odysee/Controllers/Content/HomeViewController.swift
+++ b/Odysee/Controllers/Content/HomeViewController.swift
@@ -32,11 +32,10 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
         ContentSources.MoviesChannelIds,
         ContentSources.PrimaryChannelContentIds
     ]
-    let moviesCategoryIndex: Int = 8
-    let wildWestCategoryIndex: Int = 9
+    static let moviesCategoryIndex: Int = 8
+    static let wildWestCategoryIndex: Int = 9
     var currentCategoryIndex: Int = 0
     var categoryButtons: [UIButton] = []
-    var options = Dictionary<String, Any>()
     
     let pageSize: Int = 20
     var currentPage: Int = 1
@@ -81,66 +80,67 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
         }
     }
     
-    func updateClaimSearchOptions() {
-        let isWildWest = currentCategoryIndex == wildWestCategoryIndex
+    func buildClaimSearchOptions() -> [String: Any] {
+        let isWildWest = currentCategoryIndex == Self.wildWestCategoryIndex
         let orderByValue = Helper.sortByItemValues[currentSortByIndex]
         let releaseTimeValue = currentSortByIndex == 2 ? Helper.buildReleaseTime(contentFrom: Helper.contentFromItemNames[currentContentFromIndex]) : Helper.releaseTime6Months()
         
-        options = Lbry.buildClaimSearchOptions(claimType: ["stream"], anyTags: nil, notTags: nil, channelIds: channelIds[currentCategoryIndex], notChannelIds: nil, claimIds: nil, orderBy: isWildWest ? ["trending_group", "trending_mixed"] : orderByValue, releaseTime: isWildWest ? Helper.buildReleaseTime(contentFrom: Helper.contentFromItemNames[1]) : releaseTimeValue, maxDuration: nil, limitClaimsPerChannel: currentCategoryIndex == moviesCategoryIndex ? 20 : 5, page: currentPage, pageSize: pageSize)
+        return Lbry.buildClaimSearchOptions(claimType: ["stream"], anyTags: nil, notTags: nil, channelIds: channelIds[currentCategoryIndex], notChannelIds: nil, claimIds: nil, orderBy: isWildWest ? ["trending_group", "trending_mixed"] : orderByValue, releaseTime: isWildWest ? Helper.buildReleaseTime(contentFrom: Helper.contentFromItemNames[1]) : releaseTimeValue, maxDuration: nil, limitClaimsPerChannel: currentCategoryIndex == Self.moviesCategoryIndex ? 20 : 5, page: currentPage, pageSize: pageSize)
+    }
+    
+    struct ClaimSearchResult: Decodable {
+        var items: [Claim]
+        // Temporary place for the number of items before we filtered.
+        // Set during the transform.
+        var originalItemCount: Int?
+    }
+
+    func didLoadClaims(_ result: Result<ClaimSearchResult, Error>) {
+        assert(Thread.isMainThread)
+        result.showErrorIfPresent()
+        if case let .success(payload) = result {
+            lastPageReached = payload.originalItemCount! < pageSize
+            UIView.performWithoutAnimation {
+                claimListView.performBatchUpdates({
+                    let oldCount = claims.count
+                    claims.append(contentsOf: payload.items)
+                    let indexPaths = (oldCount..<claims.count).map { IndexPath(item: $0, section: 0) }
+                    claimListView.insertRows(at: indexPaths, with: .automatic)
+                }, completion: nil)
+            }
+        }
+        loadingContainer.isHidden = true
+        loading = false
+        checkNoContent()
+        refreshControl.endRefreshing()
     }
     
     func loadClaims() {
+        assert(Thread.isMainThread)
         if (loading) {
             return
         }
         
-        DispatchQueue.main.async {
-            self.noContentView.isHidden = true
-            self.loadingContainer.isHidden = false
-        }
+        noContentView.isHidden = true
+        loadingContainer.isHidden = false
         loading = true
         
-        updateClaimSearchOptions()
-        Lbry.apiCall(method: Lbry.methodClaimSearch, params: options, connectionString: Lbry.lbrytvConnectionString, completion: { data, error in
-            guard let data = data, error == nil else {
-                self.loadingContainer.isHidden = true
-                self.loading = false
-                self.checkNoContent()
-                return
+        // Capture category index for use in sorting, before leaving main thread.
+        let category = self.currentCategoryIndex
+        Lbry.apiCall(method: Lbry.methodClaimSearch,
+                     params: buildClaimSearchOptions(),
+                     url: Lbry.lbrytvURL,
+                     transform: { payload in
+            assert(!Thread.isMainThread)
+            payload.originalItemCount = payload.items.count
+            payload.items.removeAll { Lbryio.isClaimBlocked($0) || Lbryio.isClaimFiltered($0) }
+            if category != HomeViewController.wildWestCategoryIndex {
+                payload.items.sort { $0.value!.releaseTime.flatMap(Int64.init) ?? 0 > $1.value!.releaseTime.flatMap(Int64.init) ?? 0 }
             }
-            
-            let result = data["result"] as? [String: Any]
-            let items = result?["items"] as? [[String: Any]]
-            if (items != nil) {
-                if items!.count < self.pageSize {
-                    self.lastPageReached = true
-                }
-                var loadedClaims: [Claim] = []
-                items?.forEach{ item in
-                    let data = try! JSONSerialization.data(withJSONObject: item, options: [.prettyPrinted, .sortedKeys])
-                    do {
-                        let claim: Claim? = try JSONDecoder().decode(Claim.self, from: data)
-                        if (claim != nil && !self.claims.contains(where: { $0.claimId == claim?.claimId }) && !Lbryio.isClaimFiltered(claim!) && !Lbryio.isClaimBlocked(claim!)) {
-                            loadedClaims.append(claim!)
+                        for claim in payload.items {
+                            Lbry.addClaimToCache(claim: claim)
                         }
-                    } catch let error {
-                        print(error)
-                    }
-                }
-                self.claims.append(contentsOf: loadedClaims)
-                if self.currentCategoryIndex != self.wildWestCategoryIndex {
-                    self.claims.sort(by: { Int64($0.value?.releaseTime ?? "0")! > Int64($1.value?.releaseTime ?? "0")! })
-                }
-            }
-            
-            self.loading = false
-            DispatchQueue.main.async {
-                self.loadingContainer.isHidden = true
-                self.checkNoContent()
-                self.claimListView.reloadData()
-                self.refreshControl.endRefreshing()
-            }
-        })
+        }, completion: didLoadClaims)
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -210,12 +210,11 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
     
     func resetContent() {
-        DispatchQueue.main.async {
-            self.currentPage = 1
-            self.lastPageReached = false
-            self.claims.removeAll()
-            self.claimListView.reloadData()
-        }
+        assert(Thread.isMainThread)
+        currentPage = 1
+        lastPageReached = false
+        claims.removeAll()
+        claimListView.reloadData()
     }
     
     func selectCategoryButton(button: UIButton) {
@@ -224,9 +223,8 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
     
     func checkNoContent() {
-        DispatchQueue.main.async {
-            self.noContentView.isHidden = self.claims.count > 0
-        }
+        assert(Thread.isMainThread)
+        noContentView.isHidden = !claims.isEmpty
     }
     
     func numberOfComponents(in pickerView: UIPickerView) -> Int {

--- a/Odysee/Utils/Extensions.swift
+++ b/Odysee/Utils/Extensions.swift
@@ -87,3 +87,15 @@ extension URLSession {
         }
     }
 }
+
+extension Result {
+    // If the result contains an error, show it.
+    // Must be called from the main thread.
+    func showErrorIfPresent() {
+        assert(Thread.isMainThread)
+        if case let .failure(error) = self {
+            let appDelegate = UIApplication.shared.delegate as! AppDelegate
+            appDelegate.mainController.showError(error: error)
+        }
+    }
+}


### PR DESCRIPTION
This achieves a couple things:
- Fixes occasional crashes due to sharing `HomeViewController.claims` between threads.
- Removes the parse-serialize-parse dance with Claims, cutting down time in `NSJSONSerialization`.
- Fixes images sometimes flashing when we paginate, by replacing `reloadData()` with `insertRows()` and cuts down main thread stutters.

On my iPhone 11 Pro, in a test scrolling down the home feed 10 pages:

NSJSONSerialization time
Before (213ms):
<img width="1858" alt="Screen Shot 2021-05-28 at 3 23 09 PM" src="https://user-images.githubusercontent.com/2466893/120033423-8542a080-bfc9-11eb-85c8-3c688f8e111a.png">
After (50ms):
<img width="1858" alt="Screen Shot 2021-05-28 at 3 23 18 PM" src="https://user-images.githubusercontent.com/2466893/120033461-955a8000-bfc9-11eb-8c62-16ede34dccf0.png">

Main thread time
Before (1980ms):
<img width="1858" alt="Screen Shot 2021-05-28 at 3 24 17 PM" src="https://user-images.githubusercontent.com/2466893/120033505-a3100580-bfc9-11eb-95cf-fe1bb78bfb8f.png">
After (1790ms):
<img width="1858" alt="Screen Shot 2021-05-28 at 3 24 08 PM" src="https://user-images.githubusercontent.com/2466893/120033521-a99e7d00-bfc9-11eb-92b6-17a4467e98ba.png">
