### PR TITLE
Use iOS 13-compatible logging function

### DIFF
--- a/Odysee/Controllers/Library/PublishViewController.swift
+++ b/Odysee/Controllers/Library/PublishViewController.swift
@@ -517,7 +517,7 @@ class PublishViewController: UIViewController, UIGestureRecognizerDelegate, UIPi
             do {
                 let jsonData = try JSONSerialization.data(withJSONObject: jsonPayload, options: .prettyPrinted)
                 let jsonString = String(data: jsonData, encoding: String.Encoding.utf8)!
-                os_log(.debug, log: Log.verboseJSON, "\(jsonString)")
+                Log.verboseJSON.logIfEnabled(.debug, jsonString)
                 
                 var mimeType = "application/octet-stream"
                 let pathExt = videoUrl.pathExtension
@@ -580,7 +580,7 @@ class PublishViewController: UIViewController, UIGestureRecognizerDelegate, UIPi
                     }
                     
                     do {
-                        os_log(.debug, log: Log.verboseJSON, "\(String(data: data, encoding: .utf8)!)")
+                        Log.verboseJSON.logIfEnabled(.debug, String(data: data, encoding: .utf8)!)
                         
                         let response = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
                         if (response?["result"] != nil) {

--- a/Odysee/Utils/Lbry.swift
+++ b/Odysee/Utils/Lbry.swift
@@ -105,8 +105,7 @@ final class Lbry {
             // Do the parse, compute the result here on network thread.
             let result: Result<Value, Error> = taskResult.flatMap { rawResponse in
                 Result {
-                    os_log(.debug, log: Log.verboseJSON,
-                           "Response to `\(method)`: \(String(data: rawResponse.data, encoding: .utf8)!)")
+                    Log.verboseJSON.logIfEnabled(.debug, "Response to `\(method)`: \(String(data: rawResponse.data, encoding: .utf8)!)")
 
                     let response = try JSONDecoder().decode(APIResponse<Value>.self, from: rawResponse.data)
                     assert(response.jsonrpc == "2.0")
@@ -150,7 +149,7 @@ final class Lbry {
                 return
             }
             do {
-                os_log(.debug, log: Log.verboseJSON, "Response to `\(method)`: \(String(data: data, encoding: .utf8)!)")
+                Log.verboseJSON.logIfEnabled(.debug, "Response to `\(method)`: \(String(data: data, encoding: .utf8)!)")
                 
                 let response = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
                 if (response?["result"] != nil) {

--- a/Odysee/Utils/Lbryio.swift
+++ b/Odysee/Utils/Lbryio.swift
@@ -106,7 +106,7 @@ final class Lbryio {
                 }
                 let respData = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
                 
-                os_log(.debug, log: Log.verboseJSON, "\(String(data: data, encoding: .utf8)!)")
+                Log.verboseJSON.logIfEnabled(.debug, String(data: data, encoding: .utf8)!)
                 
                 if (respCode >= 200 && respCode < 300) {
                     if (respData?["data"] == nil) {

--- a/Odysee/Utils/Log.swift
+++ b/Odysee/Utils/Log.swift
@@ -2,7 +2,7 @@
 //  Log.swift
 //  Odysee
 //
-//  Created by Adlai on 5/18/21.
+//  Created by Adlai Holler on 5/18/21.
 //
 
 import Foundation
@@ -12,4 +12,18 @@ struct Log {
     // Uncomment to print all JSON responses in debug mode.
 //    static let verboseJSON = OSLog(subsystem: "com.lbry.odysee", category: "json")
     static let verboseJSON = OSLog.disabled
+}
+
+extension OSLog {
+    // If the specified log type is enabled, create and log a string.
+    // Otherwise do nothing at all.
+    //
+    // In iOS 14+, we can replace with built-in version:
+    //    os_log(.debug, log: myLog, "Thing: \(myThing.makeExpensiveString())")
+    func logIfEnabled(_ type: OSLogType, _ msg: @autoclosure () -> String) {
+        if isEnabled(type: type) {
+            let str = msg()
+            os_log(type, log: self, "%@", str)
+        }
+    }
 }


### PR DESCRIPTION
Relates to #25. The one we were using before was only available on iOS 14+. Added a fake version that does the same thing.