### PR TITLE
Migrate PublishesViewController to new apiCall, fix threading

### DIFF
--- a/Odysee.xcodeproj/project.pbxproj
+++ b/Odysee.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		CCDDA921265852920006035F /* Multistream.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDDA920265852910006035F /* Multistream.swift */; };
 		CCDDA9232658529C0006035F /* MultistreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDDA9222658529C0006035F /* MultistreamTests.swift */; };
 		CCDDA929265861AF0006035F /* PINRemoteImage in Frameworks */ = {isa = PBXBuildFile; productRef = CCDDA928265861AF0006035F /* PINRemoteImage */; };
+		CCFB0B4F26653E0900696E0C /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = CCFB0B4E26653E0900696E0C /* OrderedCollections */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -211,6 +212,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CCFB0B4F26653E0900696E0C /* OrderedCollections in Frameworks */,
 				6459121D2620745D00B2ABA5 /* Starscream in Frameworks */,
 				B63C54A7260C990C00DD26A9 /* AuthenticationServices.framework in Frameworks */,
 				6453358B257FDC6800C49BD1 /* FirebaseMessaging in Frameworks */,
@@ -495,6 +497,7 @@
 				6459121C2620745D00B2ABA5 /* Starscream */,
 				648F70D126307BC700885A2F /* HaishinKit */,
 				CCDDA928265861AF0006035F /* PINRemoteImage */,
+				CCFB0B4E26653E0900696E0C /* OrderedCollections */,
 			);
 			productName = Odysee;
 			productReference = 64FBE79925502A290082AF2E /* Odysee.app */;
@@ -574,6 +577,7 @@
 				6459121B2620745C00B2ABA5 /* XCRemoteSwiftPackageReference "Starscream" */,
 				648F70D026307BC700885A2F /* XCRemoteSwiftPackageReference "HaishinKit" */,
 				CCDDA927265861AF0006035F /* XCRemoteSwiftPackageReference "PINRemoteImage" */,
+				CCFB0B4D26653E0800696E0C /* XCRemoteSwiftPackageReference "swift-collections" */,
 			);
 			productRefGroup = 64FBE79A25502A290082AF2E /* Products */;
 			projectDirPath = "";
@@ -1078,6 +1082,14 @@
 				revision = 93428e8b6e797d27d1f57425937c0e094d0f4ad8;
 			};
 		};
+		CCFB0B4D26653E0800696E0C /* XCRemoteSwiftPackageReference "swift-collections" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-collections";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.0.3;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1115,6 +1127,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = CCDDA927265861AF0006035F /* XCRemoteSwiftPackageReference "PINRemoteImage" */;
 			productName = PINRemoteImage;
+		};
+		CCFB0B4E26653E0900696E0C /* OrderedCollections */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CCFB0B4D26653E0800696E0C /* XCRemoteSwiftPackageReference "swift-collections" */;
+			productName = OrderedCollections;
 		};
 /* End XCSwiftPackageProductDependency section */
 

--- a/Odysee.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Odysee.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -200,6 +200,15 @@
         }
       },
       {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections",
+        "state": {
+          "branch": null,
+          "revision": "d45e63421d3dff834949ac69d3c37691e994bd69",
+          "version": "0.0.3"
+        }
+      },
+      {
         "package": "Swifter",
         "repositoryURL": "https://github.com/httpswift/swifter.git",
         "state": {

--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -780,7 +780,6 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
             
             Lbry.apiCall(method: Lbry.Methods.resolve,
                          params: ["urls": resolveUrls],
-                         url: Lbry.lbrytvURL,
                          completion: self.handleRelatedContentResult)
         })
     }

--- a/Odysee/Controllers/Content/HomeViewController.swift
+++ b/Odysee/Controllers/Content/HomeViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import Firebase
+import OrderedCollections
 import UIKit
 
 class HomeViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, UIPickerViewDelegate, UIPickerViewDataSource {
@@ -41,7 +42,7 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
     var currentPage: Int = 1
     var lastPageReached: Bool = false
     var loading: Bool = false
-    var claims: [Claim] = []
+    var claims = OrderedSet<Claim>()
     
     var sortByPicker: UIPickerView!
     var contentFromPicker: UIPickerView!

--- a/Odysee/Controllers/Content/HomeViewController.swift
+++ b/Odysee/Controllers/Content/HomeViewController.swift
@@ -123,7 +123,6 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
         var isLastPage = false
         Lbry.apiCall(method: Lbry.Methods.claimSearch,
                      params: buildClaimSearchOptions(),
-                     url: Lbry.lbrytvURL,
                      transform: { payload in
                         assert(!Thread.isMainThread)
                         isLastPage = payload.items.count < payload.page_size

--- a/Odysee/Controllers/Library/PublishesViewController.swift
+++ b/Odysee/Controllers/Library/PublishesViewController.swift
@@ -88,6 +88,7 @@ class PublishesViewController: UIViewController, UITableViewDataSource, UITableV
                     uploadsListView.insertRows(at: indexPaths, with: .none)
                 }
             }
+            Lbry.ownUploads = uploads.filter { $0.claimId != "new" }
         }
         result.showErrorIfPresent()
         loadingUploads = false

--- a/Odysee/Controllers/Library/PublishesViewController.swift
+++ b/Odysee/Controllers/Library/PublishesViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import Firebase
+import OrderedCollections
 import UIKit
 
 class PublishesViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
@@ -17,7 +18,7 @@ class PublishesViewController: UIViewController, UITableViewDataSource, UITableV
     var newPlaceholderAdded = false
     var longPressGestureRecognizer: UILongPressGestureRecognizer!
     var loadingUploads = false
-    var uploads: [Claim] = []
+    var uploads = OrderedSet<Claim>()
     var currentPage: Int = 1
     var pageSize: Int = 50
     
@@ -46,8 +47,6 @@ class PublishesViewController: UIViewController, UITableViewDataSource, UITableV
         
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
         appDelegate.mainController.toggleHeaderVisibility(hidden: false)
-        
-        loadUploads()
     }
     
     func addNewPlaceholder() {
@@ -68,45 +67,34 @@ class PublishesViewController: UIViewController, UITableViewDataSource, UITableV
         loadingUploads = true
         loadingContainer.isHidden = false
         
-        let options: Dictionary<String, Any> = ["claim_type": "stream", "page": currentPage, "page_size": pageSize, "resolve": true]
-        Lbry.apiCall(method: Lbry.methodClaimList, params: options, connectionString: Lbry.lbrytvConnectionString, authToken: Lbryio.authToken, completion: { data, error in
-            guard let data = data, error == nil else {
-                self.showError(error: error)
-                self.loadingUploads = false
-                self.loadingContainer.isHidden = true
-                self.checkNoUploads()
-                return
-            }
-            
-            let result = data["result"] as? [String: Any]
-            if let items = result?["items"] as? [[String: Any]] {
-                var loadedClaims: [Claim] = []
-                items.forEach{ item in
-                    let data = try! JSONSerialization.data(withJSONObject: item, options: [.prettyPrinted, .sortedKeys])
-                    do {
-                        let claim: Claim? = try JSONDecoder().decode(Claim.self, from: data)
-                        if (claim != nil && !self.uploads.contains(where: { $0.claimId == claim?.claimId })) {
-                            loadedClaims.append(claim!)
-                        }
-                    } catch let error {
-                        print(error)
-                    }
-                }
-                //self.uploads.removeAll()
-                //self.addNewPlaceholder()
-                self.uploads.append(contentsOf: loadedClaims)
-                Lbry.ownUploads = self.uploads.filter { $0.claimId != "new" }
-            }
-            
-            self.loadingUploads = false
-            DispatchQueue.main.async {
-                self.loadingContainer.isHidden = true
-                self.checkNoUploads()
-                self.uploadsListView.reloadData()
-            }
-        })
+        let options: [String: Any] = ["claim_type": "stream",
+                                      "page": currentPage,
+                                      "page_size": pageSize,
+                                      "resolve": true]
+        Lbry.apiCall(method: Lbry.Methods.claimList,
+                     params: options,
+                     completion: didReceiveUploads)
     }
     
+
+    func didReceiveUploads(_ result: Result<Lbry.Page<Claim>, Error>) {
+        assert(Thread.isMainThread)
+        if case let .success(page) = result {
+            UIView.performWithoutAnimation {
+                uploadsListView.performBatchUpdates {
+                    let oldCount = uploads.count
+                    uploads.append(contentsOf: page.items)
+                    let indexPaths = (oldCount..<uploads.count).map { IndexPath(item: $0, section: 0) }
+                    uploadsListView.insertRows(at: indexPaths, with: .none)
+                }
+            }
+        }
+        result.showErrorIfPresent()
+        loadingUploads = false
+        loadingContainer.isHidden = true
+        uploadsListView.isHidden = uploads.isEmpty
+        noUploadsView.isHidden = !uploads.isEmpty
+    }
 
     /*
     // MARK: - Navigation
@@ -119,20 +107,17 @@ class PublishesViewController: UIViewController, UITableViewDataSource, UITableV
     */
     
     func abandonClaim(claim: Claim) {
-        let params: Dictionary<String, Any> = ["claim_id": claim.claimId!, "blocking": true]
-        Lbry.apiCall(method: Lbry.methodStreamAbandon, params: params, connectionString: Lbry.lbrytvConnectionString, authToken: Lbryio.authToken, completion: { data, error in
-            guard let _ = data, error == nil else {
-                self.showError(error: error)
-                return
-            }
-        })
+        let params: [String: Any] = ["claim_id": claim.claimId!,
+                                     "blocking": true]
+        Lbry.apiCall(method: Lbry.Methods.streamAbandon,
+                     params: params,
+                     completion: didAbandonClaim)
     }
     
-    func checkNoUploads() {
-        DispatchQueue.main.async {
-            self.uploadsListView.isHidden = self.uploads.count == 0
-            self.noUploadsView.isHidden = self.uploads.count > 0
-        }
+    func didAbandonClaim(_ result: Result<Transaction, Error>) {
+        assert(Thread.isMainThread)
+        // TODO: Handle failure and re-insert the row.
+        result.showErrorIfPresent()
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -187,7 +172,7 @@ class PublishesViewController: UIViewController, UITableViewDataSource, UITableV
             
             if claim.confirmations ?? 0 == 0 {
                 // pending claim
-                self.showError(message: "You cannot remove a pending upload. Please try again later.")
+                self.showError(message: String.localized("You cannot remove a pending upload. Please try again later."))
                 return
             }
             

--- a/Odysee/Models/Claim.swift
+++ b/Odysee/Models/Claim.swift
@@ -114,7 +114,7 @@ class Claim: Decodable, Equatable, Hashable {
         return lhs.claimId == rhs.claimId
     }
     func hash(into hasher: inout Hasher) {
-        hasher.combine(claimId?.hashValue ?? 0)
+        claimId.hash(into: &hasher)
     }
     
 }

--- a/Odysee/Models/Claim.swift
+++ b/Odysee/Models/Claim.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class Claim: Decodable, Equatable  {
+class Claim: Decodable, Equatable, Hashable {
     var address: String?
     var amount: String?
     var canonicalUrl: String?
@@ -113,4 +113,8 @@ class Claim: Decodable, Equatable  {
     static func ==(lhs:Claim, rhs:Claim) -> Bool {
         return lhs.claimId == rhs.claimId
     }
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(claimId?.hashValue ?? 0)
+    }
+    
 }

--- a/Odysee/Utils/Lbry.swift
+++ b/Odysee/Utils/Lbry.swift
@@ -31,10 +31,13 @@ final class Lbry {
     }
 
     struct Methods {
-        static let resolve      = Method<[String: Claim]>(name: "resolve")
-        static let claimSearch  = Method<Page<Claim>>(name: "claim_search")
+        static let resolve       = Method<[String: Claim]>(name: "resolve")
+        static let claimSearch   = Method<Page<Claim>>(name: "claim_search")
+        static let claimList     = Method<Page<Claim>>(name: "claim_list")
+        static let streamAbandon = Method<Transaction>(name: "stream_abandon")
     }
 
+    // Over time these will move up into the Methods struct as we migrate to the newer apiCall func.
     static let methodClaimSearch = Methods.claimSearch.name
     static let methodResolve = Methods.resolve.name
     static let methodAddressUnused = "address_unused"
@@ -42,11 +45,10 @@ final class Lbry {
     static let methodChannelCreate = "channel_create"
     static let methodChannelUpdate = "channel_update"
     static let methodCommentCreate = "comment_create"
-    static let methodStreamAbandon = "stream_abandon"
     static let methodStreamUpdate = "stream_update"
     static let methodChannelSign = "channel_sign"
     static let methodPublish = "publish"
-    static let methodClaimList = "claim_list"
+    static let methodClaimList = Methods.claimList.name
     static let methodCommentList = "comment_list"
     static let methodCommentReact = "comment_react"
     static let methodCommentReactList = "comment_react_list"
@@ -111,8 +113,8 @@ final class Lbry {
     // Delivers the parsed Result on the main thread.
     static func apiCall<Value: Decodable>(method: Method<Value>,
                                           params: [String: Any],
-                                          url: URL,
-                                          authToken: String? = nil,
+                                          url: URL = lbrytvURL,
+                                          authToken: String? = Lbryio.authToken,
                                           transform: ((inout Value) throws -> ())? = nil,
                                           completion: @escaping (Result<Value, Error>) -> Void) {
         let req = apiRequest(method: method.name, params: params, url: url, authToken: authToken)


### PR DESCRIPTION
This resolves potential threading crashes when loading your uploads list, and improves the performance of loading it.

This OrderedSet thing from Apple will be useful in automatically de-duping claims lists.