### PR TITLE
Remove tap-to-dismiss arrow

### DIFF
--- a/Odysee/Base.lproj/Main.storyboard
+++ b/Odysee/Base.lproj/Main.storyboard
@@ -6431,30 +6431,6 @@
                             <containerView hidden="YES" opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GiF-qv-hoI">
                                 <rect key="frame" x="0.0" y="284" width="414" height="578"/>
                             </containerView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IzU-bX-6Of" userLabel="Dismiss File View">
-                                <rect key="frame" x="189" y="44" width="36" height="24"/>
-                                <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chevron.down" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="ukC-pb-N9P">
-                                        <rect key="frame" x="9" y="8" width="18" height="8.5"/>
-                                        <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="18" id="Bnd-B8-D3N"/>
-                                            <constraint firstAttribute="width" constant="18" id="iJw-t9-QJ0"/>
-                                        </constraints>
-                                    </imageView>
-                                </subviews>
-                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.90000000000000002" colorSpace="custom" customColorSpace="calibratedRGB"/>
-                                <gestureRecognizers/>
-                                <constraints>
-                                    <constraint firstItem="ukC-pb-N9P" firstAttribute="centerX" secondItem="IzU-bX-6Of" secondAttribute="centerX" id="4iW-jf-jnF"/>
-                                    <constraint firstAttribute="height" constant="24" id="S6R-8n-Fsp"/>
-                                    <constraint firstItem="ukC-pb-N9P" firstAttribute="centerY" secondItem="IzU-bX-6Of" secondAttribute="centerY" id="WwW-GM-5Fh"/>
-                                    <constraint firstAttribute="width" constant="36" id="hi4-2B-zRK"/>
-                                </constraints>
-                                <connections>
-                                    <outletCollection property="gestureRecognizers" destination="OfH-6p-L16" appends="YES" id="s4y-Gh-ixA"/>
-                                </connections>
-                            </view>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VuG-8T-cXR" userLabel="Resolving Content View">
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <subviews>
@@ -6513,14 +6489,12 @@
                             <constraint firstItem="VuG-8T-cXR" firstAttribute="height" secondItem="NdN-tQ-3r6" secondAttribute="height" id="6ST-u5-0aK"/>
                             <constraint firstItem="J4Z-JJ-JZs" firstAttribute="top" secondItem="hZs-fq-qQ6" secondAttribute="bottom" id="9LP-gD-rRi"/>
                             <constraint firstItem="NdN-tQ-3r6" firstAttribute="trailing" secondItem="hZs-fq-qQ6" secondAttribute="trailing" id="9k8-xU-Tdu"/>
-                            <constraint firstItem="IzU-bX-6Of" firstAttribute="centerX" secondItem="u0E-KJ-ZkJ" secondAttribute="centerX" id="CPk-3i-L9w"/>
                             <constraint firstItem="J4Z-JJ-JZs" firstAttribute="leading" secondItem="NdN-tQ-3r6" secondAttribute="leading" id="EBx-V0-qST"/>
                             <constraint firstItem="NdN-tQ-3r6" firstAttribute="trailing" secondItem="VuG-8T-cXR" secondAttribute="trailing" id="FTH-4f-XCU"/>
                             <constraint firstItem="hSv-c7-vMI" firstAttribute="trailing" secondItem="NdN-tQ-3r6" secondAttribute="trailing" id="Hpo-UX-khn"/>
                             <constraint firstItem="hSv-c7-vMI" firstAttribute="top" secondItem="hZs-fq-qQ6" secondAttribute="bottom" id="JEE-0W-JdI"/>
                             <constraint firstItem="VuG-8T-cXR" firstAttribute="leading" secondItem="NdN-tQ-3r6" secondAttribute="leading" id="N28-eQ-YVK"/>
                             <constraint firstItem="GiF-qv-hoI" firstAttribute="top" secondItem="hZs-fq-qQ6" secondAttribute="bottom" id="P6d-Zr-cU6"/>
-                            <constraint firstItem="IzU-bX-6Of" firstAttribute="top" secondItem="NdN-tQ-3r6" secondAttribute="top" id="RvA-XI-XvI"/>
                             <constraint firstItem="VuG-8T-cXR" firstAttribute="top" secondItem="NdN-tQ-3r6" secondAttribute="top" id="W6W-6O-Q88"/>
                             <constraint firstItem="hSv-c7-vMI" firstAttribute="leading" secondItem="NdN-tQ-3r6" secondAttribute="leading" id="Wri-Dx-7Hp"/>
                             <constraint firstItem="hSv-c7-vMI" firstAttribute="bottom" secondItem="NdN-tQ-3r6" secondAttribute="bottom" id="X8X-Tz-8bu"/>
@@ -6611,11 +6585,6 @@
                 <tapGestureRecognizer id="qen-Ay-6nN" userLabel="Bell Tap Gesture Recognizer">
                     <connections>
                         <action selector="bellTapped:" destination="Wx8-f6-Mvh" id="cyB-Mr-cbh"/>
-                    </connections>
-                </tapGestureRecognizer>
-                <tapGestureRecognizer id="OfH-6p-L16" userLabel="Dismiss File View Tap Gesture Recognizer">
-                    <connections>
-                        <action selector="dismissFileViewTapped:" destination="Wx8-f6-Mvh" id="ghM-u3-c7H"/>
                     </connections>
                 </tapGestureRecognizer>
                 <panGestureRecognizer minimumNumberOfTouches="1" id="0h5-cd-N4G" userLabel="Dismiss File View Pan Gesture Recognizer">

--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -1113,17 +1113,6 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
         appDelegate.mainController.showMessage(message: message)
     }
     
-    @IBAction func dismissFileViewTapped(_ sender: Any) {
-        let appDelegate = UIApplication.shared.delegate as! AppDelegate
-        let transition = CATransition()
-        transition.duration = 0.2
-        transition.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-        transition.type = .push
-        transition.subtype = .fromBottom
-        appDelegate.mainNavigationController?.view.layer.add(transition, forKey: kCATransition)
-        self.navigationController?.popViewController(animated: false)
-    }
-    
     var interactiveDismiss: UIPercentDrivenInteractiveTransition?
     @IBAction func dismissFileViewPanned(_ sender: Any) {
         assert(sender as? NSObject == dismissPanRecognizer)


### PR DESCRIPTION
Not sure how your designers feel about this, but now that we have pull-to-dismiss #109, the arrow seems distracting and kind of hard to tap.