### PR TITLE
Only resume the player on playbackLikelyToKeepUp in specific conditions

### DIFF
--- a/Odysee/AppDelegate.swift
+++ b/Odysee/AppDelegate.swift
@@ -49,10 +49,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             }
         }
         
-        if keyPath == "playbackLikelyToKeepUp" && player != nil {
-            if !(currentFileViewController?.playerConnected ?? false) {
-                player?.play()
-            }
+        if let player = player,
+           let item = player.currentItem,
+           keyPath == "playbackLikelyToKeepUp",
+           item.isPlaybackLikelyToKeepUp,
+           currentFileViewController?.playerConnected != true,
+           player.timeControlStatus != .paused {
+            player.play()
         }
     }
     


### PR DESCRIPTION
Fixes #85.

@akinwale Is this code intended to cover the case where the app is in the background/locked and the player goes to `playbackLikelyToKeepUp=true`?