### PR TITLE
Add a new defaultTransform field to API methods

### DIFF
--- a/Odysee/Controllers/Content/SearchViewController.swift
+++ b/Odysee/Controllers/Content/SearchViewController.swift
@@ -99,9 +99,6 @@ class SearchViewController: UIViewController,
             }
             Lbry.apiCall(method: Lbry.Methods.resolve,
                          params: params,
-                         transform: { table in
-                            table.values.forEach(Lbry.addClaimToCache)
-                         },
                          completion: self.didResolveResults)
         })
     }

--- a/Odysee/Models/Page.swift
+++ b/Odysee/Models/Page.swift
@@ -9,15 +9,17 @@ import Foundation
 
 struct Page<Item: Decodable>: Decodable {
     var pageSize: Int
-    var items: [Item] {
-        get { return _items ?? [] }
-        set { _items = newValue }
+    var items: [Item]
+    var isLastPage: Bool
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        pageSize = try container.decode(Int.self, forKey: .pageSize)
+        items = try container.decodeIfPresent([Item].self, forKey: .items) ?? []
+        isLastPage = items.count < pageSize
     }
     
-    // Server encodes [] as missing `items` key. Optional array is annoying. Workaround.
-    private var _items: [Item]?
-    
     private enum CodingKeys: String, CodingKey {
-        case _items = "items", pageSize = "page_size"
+        case items, pageSize = "page_size"
     }
 }

--- a/Odysee/Utils/Extensions.swift
+++ b/Odysee/Utils/Extensions.swift
@@ -99,3 +99,11 @@ extension Result {
         }
     }
 }
+
+extension Optional {
+    // Assert this optional is not nil (so we catch it in debug), and return `self ?? defaultValue`
+    func assertAndDefault(_ defaultValue: @autoclosure () -> Wrapped) -> Wrapped {
+        assert(self != nil)
+        return self ?? defaultValue()
+    }
+}


### PR DESCRIPTION
This way we can always cache & filter claims, without each caller needing to repeat the code to do it.