### PR TITLE
Replace snackbar with native alerts for signup for errors

### DIFF
--- a/Odysee/Controllers/MainViewController.swift
+++ b/Odysee/Controllers/MainViewController.swift
@@ -398,6 +398,12 @@ class MainViewController: UIViewController, AVPlayerViewControllerDelegate {
         }
     }
     
+    func showErrorAlert(title: String? = nil, message: String) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: String.localized("OK"), style: .default))
+        present(alert, animated: true)
+    }
+    
     func showError(message: String?) {
         DispatchQueue.main.async {
             let sb = Snackbar()

--- a/Odysee/Controllers/User/UserAccountViewController.swift
+++ b/Odysee/Controllers/User/UserAccountViewController.swift
@@ -138,7 +138,7 @@ class UserAccountViewController: UIViewController {
         
         if (email ?? "").isBlank || (password ?? "").isBlank {
             // show validation error
-            self.showError(message: String.localized("Please enter an email address and a password"))
+            self.showErrorAlert(message: String.localized("Please enter an email address and a password"))
             return
         }
         
@@ -178,7 +178,7 @@ class UserAccountViewController: UIViewController {
                 // possible invalid state
                 self.requestInProgress = false
                 self.frDelegate?.requestFinished(showSkip: true, showContinue: false)
-                self.showError(message: String.localized("An unknown error occurred. Please try again."))
+                self.showErrorAlert(message: String.localized("An unknown error occurred. Please try again."))
             })
         } catch let error {
             self.requestInProgress = false
@@ -263,10 +263,10 @@ class UserAccountViewController: UIViewController {
         }
     }
     
-    func showError(message: String?) {
+    func showErrorAlert(message: String) {
         DispatchQueue.main.async {
             let appDelegate = UIApplication.shared.delegate as! AppDelegate
-            appDelegate.mainController.showError(message: message)
+            appDelegate.mainController.showErrorAlert(message: message)
         }
     }
     
@@ -286,7 +286,7 @@ class UserAccountViewController: UIViewController {
         
         if (email ?? "").isBlank {
             // show validation error
-            self.showError(message: String.localized("Please enter your email address"))
+            self.showErrorAlert(message: String.localized("Please enter your email address"))
             return
         }
         
@@ -351,7 +351,7 @@ class UserAccountViewController: UIViewController {
         
         // password entry flow
         if (passwordField.text ?? "").isBlank {
-            self.showError(message: String.localized("Please enter your password"))
+            self.showErrorAlert(message: String.localized("Please enter your password"))
             return
         }
         
@@ -402,7 +402,7 @@ class UserAccountViewController: UIViewController {
                 // possible invalid state
                 self.requestInProgress = false
                 self.frDelegate?.requestFinished(showSkip: true, showContinue: false)
-                self.showError(message: String.localized("An unknown error occurred. Please try again."))
+                self.showErrorAlert(message: String.localized("An unknown error occurred. Please try again."))
             })
         } catch let error {
             self.requestInProgress = false


### PR DESCRIPTION
# Changes 

When pressing "Sign Up" with an empty form:
| Old Snackbar | New Native Alert |
|---|---|
| ![Simulator Screen Shot - iPhone 12 mini - old](https://user-images.githubusercontent.com/85817695/122212390-e213e580-cefb-11eb-9b5b-2ccea35bf800.png) | ![Simulator Screen Shot - iPhone 12 mini - new](https://user-images.githubusercontent.com/85817695/122212435-edffa780-cefb-11eb-814a-ed5ff214fbb3.png) |

## Why?
Google's material design (which I assume is where the snackbars are inspired from) only reccomends using snackbars for low priority messages. Instead, these signup form errors should be converted to native alerts (they are high priority as unless the user takes action the user cannot progress). Reason being it is easier for users to overlook snackbar style alerts, whereas, fullscreen-alerts prevent the user from doing anything until the alert is acknowledged. 

See [material design dialogs usage](https://material.io/components/dialogs#usage) for more information. In particular the "When to use" and "Cross-platform adaptations" subsections. 

Also the margins around the text on the old snackbar are inconsistent, which gives an unprofessional look.

# Apply this change for other error messages?

If you like the spirit of this change I would be willing to go though and find other usages of the snackbar for error messages and replace with alerts where appropriate. 