### PR TITLE
Make Claim cache an NSCache

### DIFF
--- a/Odysee/Controllers/Channel/ChannelViewController.swift
+++ b/Odysee/Controllers/Channel/ChannelViewController.swift
@@ -195,8 +195,9 @@ class ChannelViewController: UIViewController, UIGestureRecognizerDelegate, UISc
         displayResolving()
         
         let url = claimUrl!.description
-        if Lbry.claimCacheByUrl[url] != nil {
-            channelClaim = Lbry.claimCacheByUrl[url]
+
+        channelClaim = Lbry.cachedClaim(url: url)
+        if channelClaim != nil {
             DispatchQueue.main.async {
                 self.showClaimAndCheckFollowing()
             }

--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -262,8 +262,8 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
         displayResolving()
         
         let url = claimUrl!.description
-        if Lbry.claimCacheByUrl[url] != nil {
-            self.claim = Lbry.claimCacheByUrl[url]
+        claim = Lbry.cachedClaim(url: url)
+        if claim != nil {
             DispatchQueue.main.async {
                 self.showClaimAndCheckFollowing()
             }


### PR DESCRIPTION
This fixes thread-safety around the claim cache, and makes the cache automatically purge when memory is low. With a dictionary we just grow and grow.