### PR TITLE
Migrate comment author resolving to new API, fix retain cycle

### DIFF
--- a/Odysee/Controllers/Channel/ChannelViewController.swift
+++ b/Odysee/Controllers/Channel/ChannelViewController.swift
@@ -71,7 +71,7 @@ class ChannelViewController: UIViewController, UIGestureRecognizerDelegate, UISc
     var commentsLastPageReached: Bool = false
     var commentsLoading: Bool = false
     var comments: [Comment] = []
-    var authorThumbnailMap: Dictionary<String, String> = [:]
+    var authorThumbnailMap = [String: URL]()
     
     var currentCommentAsIndex = -1
     var currentSortByIndex = 1 // default to New content

--- a/Odysee/Controllers/Content/CommentsViewController.swift
+++ b/Odysee/Controllers/Content/CommentsViewController.swift
@@ -37,7 +37,7 @@ class CommentsViewController: UIViewController, UITableViewDelegate, UITableView
     var postingComment: Bool = false
     var channels: [Claim] = Lbry.ownChannels
     var comments: [Comment] = []
-    var authorThumbnailMap: Dictionary<String, String> = [:]
+    var authorThumbnailMap = [String: URL]()
     var isChannelComments = false
     var reacting = false
     
@@ -195,32 +195,17 @@ class CommentsViewController: UIViewController, UITableViewDelegate, UITableView
 
     func resolveCommentAuthors(urls: [String]) {
         let params = ["urls": urls]
-        Lbry.apiCall(method: Lbry.methodResolve, params: params, connectionString: Lbry.lbrytvConnectionString, completion: { [self] data, error in
-            guard let data = data, error == nil else {
-                return
-            }
-            
-            let result = data["result"] as! NSDictionary
-            for (url, claimData) in result {
-                let data = try! JSONSerialization.data(withJSONObject: claimData, options: [.prettyPrinted, .sortedKeys])
-                do {
-                    let claim: Claim? = try JSONDecoder().decode(Claim.self, from: data)
-                    if claim != nil && !(claim!.claimId ?? "").isBlank {
-                        if claim!.value != nil && claim!.value!.thumbnail != nil && !(claim!.value!.thumbnail!.url ?? "").isBlank {
-                            self.authorThumbnailMap[url as! String] = claim!.value!.thumbnail!.url!
-                        }
-                    }
-                } catch {
-                    // pass
-                }
-            }
-            
-            DispatchQueue.main.async {
-                commentList.reloadData()
-            }
-        })
+        Lbry.apiCall(method: Lbry.Methods.resolve, params: params, completion: didResolveCommentAuthors)
     }
     
+    func didResolveCommentAuthors(_ result: Result<[String: Claim], Error>) {
+        guard case let .success(dict) = result else {
+            return
+        }
+        Helper.addThumbURLs(claims: dict, thumbURLs: &authorThumbnailMap)
+        commentList.reloadData()
+    }
+
     func loadChannels() {
         if channels.count > 0 {
             return

--- a/Odysee/UI/CommentTableViewCell.swift
+++ b/Odysee/UI/CommentTableViewCell.swift
@@ -9,9 +9,9 @@ import UIKit
 
 class CommentTableViewCell: UITableViewCell {
 
-    var viewController: CommentsViewController?
+    weak var viewController: CommentsViewController?
     var currentComment: Comment?
-    var authorImageMap: Dictionary<String, String> = [:]
+    var authorImageMap = [String: URL]()
     
     @IBOutlet weak var authorThumbnailView: UIImageView!
     @IBOutlet weak var authorNameLabel: UILabel!
@@ -39,16 +39,16 @@ class CommentTableViewCell: UITableViewCell {
         // Configure the view for the selected state
     }
     
-    func setAuthorImageMap(map: Dictionary<String, String>) {
+    func setAuthorImageMap(map: [String: URL]) {
         authorImageMap = map
         displayAuthorImage()
     }
     
     func displayAuthorImage() {
         if currentComment?.channelUrl != nil {
-            if let thumbnailUrlStr = authorImageMap[currentComment!.channelUrl!] {
+            if let thumbnailUrl = authorImageMap[currentComment!.channelUrl!] {
                 authorThumbnailView.backgroundColor = UIColor.clear
-                authorThumbnailView.load(url: URL(string: thumbnailUrlStr)!)
+                authorThumbnailView.load(url: thumbnailUrl)
             } else {
                 authorThumbnailView.image = UIImage.init(named: "spaceman")
                 authorThumbnailView.backgroundColor = Helper.lightPrimaryColor

--- a/Odysee/UI/NotificationTableViewCell.swift
+++ b/Odysee/UI/NotificationTableViewCell.swift
@@ -16,7 +16,7 @@ class NotificationTableViewCell: UITableViewCell {
     @IBOutlet weak var timeView: UILabel!
     @IBOutlet weak var unreadIndicatorView: UIView!
     
-    var authorImageMap: Dictionary<String, String> = [:]
+    var authorImageMap = [String: URL]()
     var currentNotification: LbryNotification?
     
     override func awakeFromNib() {
@@ -30,16 +30,16 @@ class NotificationTableViewCell: UITableViewCell {
         // Configure the view for the selected state
     }
     
-    func setAuthorImageMap(map: Dictionary<String, String>) {
+    func setAuthorImageMap(map: [String: URL]) {
         authorImageMap = map
         displayAuthorImage()
     }
     
     func displayAuthorImage() {
         if currentNotification?.author != nil {
-            if let thumbnailUrlStr = authorImageMap[currentNotification!.author!] {
+            if let thumbnailUrl = authorImageMap[currentNotification!.author!] {
                 avatarView.backgroundColor = UIColor.clear
-                avatarView.load(url: URL(string: thumbnailUrlStr)!)
+                avatarView.load(url: thumbnailUrl)
             }
         }
     }

--- a/Odysee/Utils/Helper.swift
+++ b/Odysee/Utils/Helper.swift
@@ -261,13 +261,21 @@ final class Helper {
     }
     
     static func claimContainsTag(claim: Claim, tag: String) -> Bool {
-        return claim.value != nil && claim.value!.tags != nil &&
-            claim.value!.tags!.filter{ $0.lowercased() == tag.lowercased() }.count > 0
+        return claim.value?.tags?.contains { $0.caseInsensitiveCompare(tag) == .orderedSame } ?? false
     }
     
     static func strToHex(_ str: String) -> String {
         let data = Data(str.utf8)
         return data.map{ String(format: "%02x", $0) }.joined()
+    }
+    
+    static func addThumbURLs(claims: [String: Claim], thumbURLs: inout [String: URL]) {
+        thumbURLs.reserveCapacity(thumbURLs.count + claims.count)
+        for (url, claim) in claims {
+            if let thumbUrl = claim.value?.thumbnail?.url.flatMap(URL.init) {
+                thumbURLs[url] = thumbUrl
+            }
+        }
     }
 }
 


### PR DESCRIPTION
CommentTableViewCell.viewController needs to be weak, or else we have a retain cycle: `View controller -> self.view -> UITableView -> cells -> view controller`. So we leak memory.