### PR TITLE
Use new image CDN URLs for thumbs and channel avatars

### DIFF
--- a/Odysee.xcodeproj/project.pbxproj
+++ b/Odysee.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		64FF821A260507D2009B7A3B /* CreateChannelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64FF8219260507D2009B7A3B /* CreateChannelViewController.swift */; };
 		B63C54A7260C990C00DD26A9 /* AuthenticationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B63C54A6260C990C00DD26A9 /* AuthenticationServices.framework */; };
 		CC004D5A2662868300514FDF /* ClaimTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CC004D592662868300514FDF /* ClaimTableViewCell.xib */; };
+		CC015766267A9C1100F96EFE /* ImageURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC015765267A9C1100F96EFE /* ImageURLs.swift */; };
 		CC0B2B0D266D0E72002490BB /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0B2B0C266D0E72002490BB /* Lock.swift */; };
 		CC48F4FC2662B2020018D958 /* VideoPickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC48F4FB2662B2020018D958 /* VideoPickerController.swift */; };
 		CC49954526692037001BB2DC /* ImagePrefetchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC49954426692037001BB2DC /* ImagePrefetchController.swift */; };
@@ -203,6 +204,7 @@
 		64FF8219260507D2009B7A3B /* CreateChannelViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateChannelViewController.swift; sourceTree = "<group>"; };
 		B63C54A6260C990C00DD26A9 /* AuthenticationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AuthenticationServices.framework; path = System/Library/Frameworks/AuthenticationServices.framework; sourceTree = SDKROOT; };
 		CC004D592662868300514FDF /* ClaimTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ClaimTableViewCell.xib; sourceTree = "<group>"; };
+		CC015765267A9C1100F96EFE /* ImageURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageURLs.swift; sourceTree = "<group>"; };
 		CC0B2B0C266D0E72002490BB /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		CC48F4FB2662B2020018D958 /* VideoPickerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPickerController.swift; sourceTree = "<group>"; };
 		CC49954426692037001BB2DC /* ImagePrefetchController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePrefetchController.swift; sourceTree = "<group>"; };
@@ -280,6 +282,7 @@
 				CC97807826549867009F580E /* Log.swift */,
 				6413274D2557D89200CBB6B8 /* Extensions.swift */,
 				64424DD9255895A500F2D247 /* ContentSources.swift */,
+				CC015765267A9C1100F96EFE /* ImageURLs.swift */,
 				641108DB255A8D7D00F0FB8A /* Lbryio.swift */,
 				CC0B2B0C266D0E72002490BB /* Lock.swift */,
 				641108F0255AF6CD00F0FB8A /* Helper.swift */,
@@ -693,6 +696,7 @@
 				64666AF62587290200DF4608 /* ChannelListTableViewCell.swift in Sources */,
 				640BEF2F2587A8FA0019B840 /* LbryNotification.swift in Sources */,
 				64D0CFED25728D2A00A89B0A /* FollowingViewController.swift in Sources */,
+				CC015766267A9C1100F96EFE /* ImageURLs.swift in Sources */,
 				641682D825ACBA7800BCDC3A /* CommentsViewController.swift in Sources */,
 				646E54E2257E276400BEBFBE /* LbrySubscription.swift in Sources */,
 				64D72BC3258CDEC400F5C4E3 /* Reward.swift in Sources */,

--- a/Odysee/UI/ClaimTableViewCell.swift
+++ b/Odysee/UI/ClaimTableViewCell.swift
@@ -11,6 +11,8 @@ class ClaimTableViewCell: UITableViewCell {
 
     static let nib = UINib(nibName: "ClaimTableViewCell", bundle: nil)
     static let spacemanImage = UIImage(named: "spaceman")
+    static let thumbImageSpec = ImageSpec(size: CGSize(width: 160, height: 90))
+    static let channelImageSpec = ImageSpec(size: CGSize(width: 90, height: 90))
 
     @IBOutlet var channelImageView: UIImageView!
     @IBOutlet var thumbnailImageView: UIImageView!
@@ -38,7 +40,9 @@ class ClaimTableViewCell: UITableViewCell {
         
         var result = [URL]()
         if let thumbnailUrl = claim.value?.thumbnail?.url.flatMap(URL.init) {
-            result.append(thumbnailUrl)
+            let isChannel = claim.name?.starts(with: "@") ?? false
+            let spec = isChannel ? Self.channelImageSpec : Self.thumbImageSpec
+            result.append(thumbnailUrl.makeImageURL(spec: spec))
         }
         return result
     }
@@ -46,8 +50,10 @@ class ClaimTableViewCell: UITableViewCell {
     func setClaim(claim: Claim) {
         if (currentClaim != nil && claim.claimId != currentClaim!.claimId) {
             // reset the thumbnail image (to prevent the user from seeing image load changes when scrolling due to cell reuse)
+            thumbnailImageView.pin_cancelImageDownload()
             thumbnailImageView.image = nil
             thumbnailImageView.backgroundColor = nil
+            channelImageView.pin_cancelImageDownload()
             channelImageView.image = nil
             channelImageView.backgroundColor = nil
         }
@@ -87,17 +93,17 @@ class ClaimTableViewCell: UITableViewCell {
         // load thumbnail url
         if let thumbnailUrl = claim.value?.thumbnail?.url.flatMap(URL.init) {
             if isChannel {
-                channelImageView.load(url: thumbnailUrl)
+                channelImageView.load(url: thumbnailUrl.makeImageURL(spec: Self.channelImageSpec))
             } else {
-                thumbnailImageView.load(url: thumbnailUrl)
+                thumbnailImageView.load(url: thumbnailUrl.makeImageURL(spec: Self.thumbImageSpec))
             }
         } else {
             if isChannel {
-                thumbnailImageView.image = Self.spacemanImage
-                thumbnailImageView.backgroundColor = Helper.lightPrimaryColor
-            } else {
                 channelImageView.image = Self.spacemanImage
                 channelImageView.backgroundColor = Helper.lightPrimaryColor
+            } else {
+                thumbnailImageView.image = Self.spacemanImage
+                thumbnailImageView.backgroundColor = Helper.lightPrimaryColor
             }
         }
         

--- a/Odysee/Utils/ImageURLs.swift
+++ b/Odysee/Utils/ImageURLs.swift
@@ -1,0 +1,44 @@
+//
+//  ImageURLs.swift
+//  Odysee
+//
+//  Created by Adlai Holler on 6/16/21.
+//
+
+import Foundation
+import PINRemoteImage
+import UIKit
+
+fileprivate let kImageServerBaseURL = "https://image-processor.vanwanet.com/optimize/"
+fileprivate let kScale = UIScreen.main.scale
+
+struct ImageSpec {
+    var size: CGSize?
+    var quality: Int?
+    var format: String? = "webp"
+    
+    func appendPathSpecifier(to str: inout String) {
+        if let size = size {
+            str += "s:\(Int(size.width * kScale)):\(Int(size.height * kScale))/"
+        }
+        if let quality = quality {
+            str += "quality:\(quality)/"
+        }
+    }
+    func appendFormatSpecifier(to str: inout String) {
+        if let format = format {
+            str += "@\(format)"
+        }
+    }
+}
+
+extension URL {
+    func makeImageURL(spec: ImageSpec) -> URL {
+        var str = kImageServerBaseURL
+        spec.appendPathSpecifier(to: &str)
+        str += "plain/"
+        str += absoluteString
+        spec.appendFormatSpecifier(to: &str)
+        return URL(string: str)!
+    }
+}


### PR DESCRIPTION
This new CDN is a huge improvement. Much smaller images means lower memory usage, bandwidth, CPU, and GPU usage. After scrolling down 5 pages on home, RAM usage was at 42MB instead of 50MB. Fixes #172 