### PR TITLE
Handle errors returned from the resolve endpoint

### DIFF
--- a/Odysee.xcodeproj/project.pbxproj
+++ b/Odysee.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		B63C54A7260C990C00DD26A9 /* AuthenticationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B63C54A6260C990C00DD26A9 /* AuthenticationServices.framework */; };
 		CC004D5A2662868300514FDF /* ClaimTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CC004D592662868300514FDF /* ClaimTableViewCell.xib */; };
 		CC015766267A9C1100F96EFE /* ImageURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC015765267A9C1100F96EFE /* ImageURLs.swift */; };
+		CC015768267C1A0B00F96EFE /* ResolveResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC015767267C1A0B00F96EFE /* ResolveResult.swift */; };
 		CC0B2B0D266D0E72002490BB /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0B2B0C266D0E72002490BB /* Lock.swift */; };
 		CC48F4FC2662B2020018D958 /* VideoPickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC48F4FB2662B2020018D958 /* VideoPickerController.swift */; };
 		CC49954526692037001BB2DC /* ImagePrefetchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC49954426692037001BB2DC /* ImagePrefetchController.swift */; };
@@ -205,6 +206,7 @@
 		B63C54A6260C990C00DD26A9 /* AuthenticationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AuthenticationServices.framework; path = System/Library/Frameworks/AuthenticationServices.framework; sourceTree = SDKROOT; };
 		CC004D592662868300514FDF /* ClaimTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ClaimTableViewCell.xib; sourceTree = "<group>"; };
 		CC015765267A9C1100F96EFE /* ImageURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageURLs.swift; sourceTree = "<group>"; };
+		CC015767267C1A0B00F96EFE /* ResolveResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolveResult.swift; sourceTree = "<group>"; };
 		CC0B2B0C266D0E72002490BB /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		CC48F4FB2662B2020018D958 /* VideoPickerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPickerController.swift; sourceTree = "<group>"; };
 		CC49954426692037001BB2DC /* ImagePrefetchController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePrefetchController.swift; sourceTree = "<group>"; };
@@ -267,6 +269,7 @@
 				642B6B0B257AB9F200F17355 /* WalletBalance.swift */,
 				642B6B10257B4CBC00F17355 /* Transaction.swift */,
 				646E4A5E259CF13A0008C9C8 /* Comment.swift */,
+				CC015767267C1A0B00F96EFE /* ResolveResult.swift */,
 				641E7EC02608BE0C00A79CD3 /* Language.swift */,
 				CC80EC0E2672A80700CA07DA /* Page.swift */,
 				641E7EC52608BE5700A79CD3 /* License.swift */,
@@ -648,6 +651,7 @@
 				6451659625DEA8B2009FAC39 /* YouTubeSyncViewController.swift in Sources */,
 				646E54DD257DCD6100BEBFBE /* UIPaddedLabel.swift in Sources */,
 				645912222620789E00B2ABA5 /* ChatMessageTableViewCell.swift in Sources */,
+				CC015768267C1A0B00F96EFE /* ResolveResult.swift in Sources */,
 				64D72BBA258C952A00F5C4E3 /* RewardVerified.swift in Sources */,
 				64BAFBB22609ED5900BD4B9A /* LibraryViewController.swift in Sources */,
 				641327442556EB2200CBB6B8 /* LbryUri.swift in Sources */,

--- a/Odysee/Controllers/Content/CommentsViewController.swift
+++ b/Odysee/Controllers/Content/CommentsViewController.swift
@@ -198,11 +198,11 @@ class CommentsViewController: UIViewController, UITableViewDelegate, UITableView
         Lbry.apiCall(method: Lbry.Methods.resolve, params: params, completion: didResolveCommentAuthors)
     }
     
-    func didResolveCommentAuthors(_ result: Result<[String: Claim], Error>) {
-        guard case let .success(dict) = result else {
+    func didResolveCommentAuthors(_ result: Result<ResolveResult, Error>) {
+        guard case let .success(resolve) = result else {
             return
         }
-        Helper.addThumbURLs(claims: dict, thumbURLs: &authorThumbnailMap)
+        Helper.addThumbURLs(claims: resolve.claims, thumbURLs: &authorThumbnailMap)
         commentList.reloadData()
     }
 

--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -276,8 +276,8 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
         Lbry.apiCall(method: Lbry.Methods.resolve, params: params, completion: didResolveClaim)
     }
     
-    func didResolveClaim(_ result: Result<[String: Claim], Error>) {
-        guard case let .success(dict) = result, let entry = dict.first else {
+    func didResolveClaim(_ result: Result<ResolveResult, Error>) {
+        guard case let .success(resolve) = result, let entry = resolve.claims.first else {
             displayNothingAtLocation()
             return
         }
@@ -770,11 +770,11 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
     }
 
     // The main-thread part of the related content loading flow, at the end.
-    func handleRelatedContentResult(_ result: Result<[String: Claim], Error>) {
+    func handleRelatedContentResult(_ result: Result<ResolveResult, Error>) {
         assert(Thread.isMainThread)
-        if case let .success(claims) = result {
+        if case let .success(resolve) = result {
             // Filter out self.claim.
-            relatedContent = claims.values.filter { testClaim in
+            relatedContent = resolve.claims.values.filter { testClaim in
                 let testID = testClaim.claimId
                 return testID != self.claim?.claimId
             }
@@ -1249,11 +1249,11 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
         Lbry.apiCall(method: Lbry.Methods.resolve, params: params, completion: didResolveCommentAuthors)
     }
     
-    func didResolveCommentAuthors(_ result: Result<[String: Claim], Error>) {
-        guard case let .success(dict) = result else {
+    func didResolveCommentAuthors(_ result: Result<ResolveResult, Error>) {
+        guard case let .success(resolve) = result else {
             return
         }
-        Helper.addThumbURLs(claims: dict, thumbURLs: &authorThumbnailMap)
+        Helper.addThumbURLs(claims: resolve.claims, thumbURLs: &authorThumbnailMap)
         checkFeaturedComment()
     }
     

--- a/Odysee/Controllers/Content/SearchViewController.swift
+++ b/Odysee/Controllers/Content/SearchViewController.swift
@@ -103,11 +103,11 @@ class SearchViewController: UIViewController,
         })
     }
     
-    func didResolveResults(_ result: Result<[String: Claim], Error>) {
+    func didResolveResults(_ result: Result<ResolveResult, Error>) {
         result.showErrorIfPresent()
-        if case let .success(claimDict) = result {
+        if case let .success(resolve) = result {
             let oldCount = claims.count
-            claims.append(contentsOf: claimDict.values)
+            claims.append(contentsOf: resolve.claims.values)
             if claims.count != oldCount {
                 resultsListView.reloadData()
             }

--- a/Odysee/Controllers/User/NotificationsViewController.swift
+++ b/Odysee/Controllers/User/NotificationsViewController.swift
@@ -209,11 +209,11 @@ class NotificationsViewController: UIViewController, UIGestureRecognizerDelegate
         Lbry.apiCall(method: Lbry.Methods.resolve, params: params, completion: didResolveCommentAuthors)
     }
     
-    func didResolveCommentAuthors(_ result: Result<[String: Claim], Error>) {
-        guard case let .success(dict) = result else {
+    func didResolveCommentAuthors(_ result: Result<ResolveResult, Error>) {
+        guard case let .success(resolve) = result else {
             return
         }
-        Helper.addThumbURLs(claims: dict, thumbURLs: &authorThumbnailMap)
+        Helper.addThumbURLs(claims: resolve.claims, thumbURLs: &authorThumbnailMap)
         notificationsListView.reloadData()
     }
 

--- a/Odysee/Models/ResolveResult.swift
+++ b/Odysee/Models/ResolveResult.swift
@@ -1,0 +1,54 @@
+//
+//  ResolveResult.swift
+//  Odysee
+//
+//  Created by Adlai Holler on 6/17/21.
+//
+
+struct ResolveResult: Decodable {
+    var claims = [String: Claim]()
+    var errors = [String: Error]()
+
+    init(from decoder: Decoder) throws {
+        let dict = try [String: ResolveItemResult](from: decoder)
+        claims.reserveCapacity(dict.count)
+        for (key, val) in dict {
+            switch val {
+            case let .success(claim):
+                claims[key] = claim
+            case let .failure(error):
+                errors[key] = error
+            }
+        }
+    }
+}
+
+private struct ResolveError: Decodable, Error {
+    var name: String?
+    var text: String?
+}
+
+// Similar to Swift.Result<Claim, Error> but decodable.
+private enum ResolveItemResult: Decodable {
+    case failure(Error)
+    case success(Claim)
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let error = try container.decodeIfPresent(ResolveError.self, forKey: CodingKeys.error) {
+            self = .failure(error)
+            return
+        }
+        let claim = try Claim(from: decoder)
+        if claim.claimId != nil {
+            self = .success(claim)
+        } else {
+            assertionFailure()
+            self = .failure(GenericError("Failed to decode resolve result"))
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case error
+    }
+}


### PR DESCRIPTION
I think I broke this in my API migrations. The old code would ignore these, by parsing them as Claims and then ignoring Claims with no `claim_id`.

Without this fix you will get crashes on failed resolves so let's land.