### PR TITLE
Make api calls into Publishers

### DIFF
--- a/Odysee/Controllers/Channel/ChannelManagerViewController.swift
+++ b/Odysee/Controllers/Channel/ChannelManagerViewController.swift
@@ -76,8 +76,8 @@ class ChannelManagerViewController: UIViewController, UITableViewDelegate, UITab
                         claimType: [.channel],
                         page: 1,
                         pageSize: 999,
-                        resolve: true),
-                     completion: didLoadChannels)
+                        resolve: true))
+            .subscribeResult(didLoadChannels)
     }
     
     func didLoadChannels(_ result: Result<Page<Claim>, Error>) {
@@ -101,10 +101,10 @@ class ChannelManagerViewController: UIViewController, UITableViewDelegate, UITab
         Lbry.apiCall(method: Lbry.Methods.channelAbandon,
                      params: .init(
                         claimId: channel.claimId!,
-                        blocking: true),
-                     completion: { result in
-                        result.showErrorIfPresent()
-                     })
+                        blocking: true))
+            .subscribeResult { result in
+                result.showErrorIfPresent()
+            }
     }
     
     func checkNoChannels() {

--- a/Odysee/Controllers/Channel/ChannelViewController.swift
+++ b/Odysee/Controllers/Channel/ChannelViewController.swift
@@ -173,8 +173,8 @@ class ChannelViewController: UIViewController, UIGestureRecognizerDelegate, UISc
                         claimType: [.channel],
                         page: 1,
                         pageSize: 999,
-                        resolve: true),
-                     completion: didLoadChannels)
+                        resolve: true))
+            .subscribeResult(didLoadChannels)
     }
     
     func didLoadChannels(_ result: Result<Page<Claim>, Error>) {
@@ -199,8 +199,8 @@ class ChannelViewController: UIViewController, UIGestureRecognizerDelegate, UISc
         }
         
         Lbry.apiCall(method: Lbry.Methods.resolve,
-                     params: .init(urls: [url]),
-                     completion: didResolveClaim)
+                     params: .init(urls: [url]))
+            .subscribeResult(didResolveClaim)
     }
     
     func didResolveClaim(_ result: Result<ResolveResult, Error>) {
@@ -351,8 +351,8 @@ class ChannelViewController: UIViewController, UIGestureRecognizerDelegate, UISc
                         pageSize: pageSize,
                         releaseTime: releaseTimeValue,
                         channelIds: [channelClaim?.claimId ?? ""],
-                        orderBy: Helper.sortByItemValues[currentSortByIndex]),
-                     completion: didLoadContent)
+                        orderBy: Helper.sortByItemValues[currentSortByIndex]))
+            .subscribeResult(didLoadContent)
     }
     
     func didLoadContent(_ result: Result<Page<Claim>, Error>) {
@@ -383,8 +383,8 @@ class ChannelViewController: UIViewController, UIGestureRecognizerDelegate, UISc
                         pageSize: pageSize,
                         hasNoSource: true,
                         channelIds: [channelClaim?.claimId ?? ""],
-                        orderBy: Helper.sortByItemValues[1]),
-                     completion: didCheckLivestream)
+                        orderBy: Helper.sortByItemValues[1]))
+            .subscribeResult(didCheckLivestream)
     }
     
     func didCheckLivestream(_ result: Result<Page<Claim>, Error>) {

--- a/Odysee/Controllers/Content/CommentsViewController.swift
+++ b/Odysee/Controllers/Content/CommentsViewController.swift
@@ -204,8 +204,8 @@ class CommentsViewController: UIViewController, UITableViewDelegate, UITableView
 
     func resolveCommentAuthors(urls: [String]) {
         Lbry.apiCall(method: Lbry.Methods.resolve,
-                     params: .init(urls: urls),
-                     completion: didResolveCommentAuthors)
+                     params: .init(urls: urls))
+            .subscribeResult(didResolveCommentAuthors)
     }
     
     func didResolveCommentAuthors(_ result: Result<ResolveResult, Error>) {
@@ -226,8 +226,8 @@ class CommentsViewController: UIViewController, UITableViewDelegate, UITableView
                         claimType: [.channel],
                         page: 1,
                         pageSize: 999,
-                        resolve: true),
-                     completion: didLoadChannels)
+                        resolve: true))
+            .subscribeResult(didLoadChannels)
     }
     
     func didLoadChannels(_ result: Result<Page<Claim>, Error>) {

--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -306,8 +306,8 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
         }
         
         Lbry.apiCall(method: Lbry.Methods.resolve,
-                     params: .init(urls: [url]),
-                     completion: didResolveClaim)
+                     params: .init(urls: [url]))
+            .subscribeResult(didResolveClaim)
     }
     
     func didResolveClaim(_ result: Result<ResolveResult, Error>) {
@@ -798,7 +798,11 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
         let defaults = UserDefaults.standard
         let receiveAddress = defaults.string(forKey: Helper.keyReceiveAddress)
         if ((receiveAddress ?? "").isBlank) {
-            Lbry.apiCall(method: Lbry.Methods.addressUnused, params: .init()) { result in
+            Lbry.apiCall(
+                method: Lbry.Methods.addressUnused,
+                params: .init()
+            )
+            .subscribeResult { result in
                 guard case let .success(newAddress) = result else {
                     return
                 }
@@ -991,8 +995,8 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
                             page: currentPlaylistPage,
                             pageSize: playlistPageSize,
                             claimIds: playlistClaims,
-                            orderBy: Helper.sortByItemValues[1]),
-                         completion: didLoadPlaylistClaims)
+                            orderBy: Helper.sortByItemValues[1]))
+                .subscribeResult(didLoadPlaylistClaims)
         }
     }
     
@@ -1086,8 +1090,8 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
                 LbryUri.tryParse(url: String(format: "%@#%@", item["name"] as! String, item["claimId"] as! String), requireProto: false)?.description
             }
             Lbry.apiCall(method: Lbry.Methods.resolve,
-                         params: .init(urls: urls),
-                         completion: self.handleRelatedContentResult)
+                         params: .init(urls: urls))
+                .subscribeResult(self.handleRelatedContentResult)
         })
     }
 
@@ -1559,8 +1563,8 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
                         claimId: singleClaim.claimId!,
                         page: commentsCurrentPage,
                         pageSize: commentsPageSize,
-                        skipValidation: true),
-                     completion: didLoadComments)
+                        skipValidation: true))
+            .subscribeResult(didLoadComments)
     }
     
     func didLoadComments(_ result: Result<Page<Comment>, Error>) {
@@ -1599,8 +1603,8 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
     
     func resolveCommentAuthors(urls: [String]) {
         Lbry.apiCall(method: Lbry.Methods.resolve,
-                     params: .init(urls: urls),
-                     completion: didResolveCommentAuthors)
+                     params: .init(urls: urls))
+            .subscribeResult(didResolveCommentAuthors)
     }
     
     func didResolveCommentAuthors(_ result: Result<ResolveResult, Error>) {
@@ -1627,8 +1631,8 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
                         claimType: [.channel],
                         page: 1,
                         pageSize: 999,
-                        resolve: true),
-                     completion: didLoadChannels)
+                        resolve: true))
+            .subscribeResult(didLoadChannels)
     }
     
     func didLoadChannels(_ result: Result<Page<Claim>, Error>) {
@@ -1660,8 +1664,8 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
                         claimId: claim!.claimId!,
                         page: 1,
                         pageSize: 75,
-                        skipValidation: true),
-                     completion: didLoadInitialChatMessages)
+                        skipValidation: true))
+            .subscribeResult(didLoadInitialChatMessages)
     }
     
     func didLoadInitialChatMessages(_ result: Result<Page<Comment>, Error>) {

--- a/Odysee/Controllers/Content/FollowingViewController.swift
+++ b/Odysee/Controllers/Content/FollowingViewController.swift
@@ -228,8 +228,8 @@ class FollowingViewController: UIViewController, UICollectionViewDataSource, UIC
                         pageSize: suggestedPageSize,
                         notChannelIds: following.map { $0.claimId! },
                         claimIds: ContentSources.PrimaryChannelContentIds,
-                        orderBy: ["effective_amount"]),
-                     completion: didLoadSuggestedFollows)
+                        orderBy: ["effective_amount"]))
+            .subscribeResult(didLoadSuggestedFollows)
     }
     
     func didLoadSuggestedFollows(_ result: Result<Page<Claim>, Error>) {
@@ -273,8 +273,8 @@ class FollowingViewController: UIViewController, UICollectionViewDataSource, UIC
                         channelIds: !selectedChannelIds.isEmpty ?
                             selectedChannelIds :
                             following.compactMap { $0.claimId },
-                        orderBy: Helper.sortByItemValues[currentSortByIndex]),
-                     completion: didLoadSubscriptionContent)
+                        orderBy: Helper.sortByItemValues[currentSortByIndex]))
+            .subscribeResult(didLoadSubscriptionContent)
     }
     
     func didLoadSubscriptionContent(_ result: Result<Page<Claim>, Error>) {
@@ -528,10 +528,10 @@ class FollowingViewController: UIViewController, UICollectionViewDataSource, UIC
         Lbry.apiCall(method: Lbry.Methods.resolve,
                      params: .init(
                         urls: subscriptions.compactMap { $0.url }
-                     ),
-                     completion: { result in
-                        self.didResolveChannelList(result, refresh: refresh)
-                     })
+                     ))
+            .subscribeResult { result in
+                self.didResolveChannelList(result, refresh: refresh)
+            }
     }
 
     func didResolveChannelList(_ result: Result<ResolveResult, Error>, refresh: Bool) {

--- a/Odysee/Controllers/Content/HomeViewController.swift
+++ b/Odysee/Controllers/Content/HomeViewController.swift
@@ -144,7 +144,8 @@ class HomeViewController: UIViewController,
                         if category != HomeViewController.wildWestCategoryIndex {
                             page.items.sort { $0.value!.releaseTime.flatMap(Int64.init) ?? 0 > $1.value!.releaseTime.flatMap(Int64.init) ?? 0 }
                         }
-                     }, completion: didLoadClaims)
+                     })
+            .subscribeResult(didLoadClaims)
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/Odysee/Controllers/Content/SearchViewController.swift
+++ b/Odysee/Controllers/Content/SearchViewController.swift
@@ -77,8 +77,8 @@ class SearchViewController: UIViewController,
         }
         
         Lbry.apiCall(method: Lbry.Methods.resolve,
-                     params: .init(urls: possibleUrls),
-                     completion: didResolveWinning)
+                     params: .init(urls: possibleUrls))
+            .subscribeResult(didResolveWinning)
     }
     
     func didResolveWinning(_ result: Result<ResolveResult, Error>) {
@@ -132,8 +132,8 @@ class SearchViewController: UIViewController,
                 LbryUri.tryParse(url: String(format: "%@#%@", item["name"] as! String, item["claimId"] as! String), requireProto: false)?.description
             }
             Lbry.apiCall(method: Lbry.Methods.resolve,
-                         params: .init(urls: urls),
-                         completion: self.didResolveResults)
+                         params: .init(urls: urls))
+                .subscribeResult(self.didResolveResults)
         })
     }
     

--- a/Odysee/Controllers/Content/SupportViewController.swift
+++ b/Odysee/Controllers/Content/SupportViewController.swift
@@ -78,8 +78,8 @@ class SupportViewController: UIViewController, UITextFieldDelegate, UIPickerView
                         claimType: [.channel],
                         page: 1,
                         pageSize: 999,
-                        resolve: true),
-                     completion: didLoadChannels)
+                        resolve: true))
+            .subscribeResult(didLoadChannels)
     }
     
     func didLoadChannels(_ result: Result<Page<Claim>, Error>) {

--- a/Odysee/Controllers/FirstRun/CreateChannelViewController.swift
+++ b/Odysee/Controllers/FirstRun/CreateChannelViewController.swift
@@ -55,9 +55,11 @@ class CreateChannelViewController: UIViewController, UITextFieldDelegate {
     func loadAndCheckChannels() {
         frDelegate?.requestStarted()
         
-        Lbry.apiCall(method: Lbry.Methods.claimList,
-                     params: .init(claimType: [.channel], page: 1, pageSize: 999),
-                     completion: didLoadChannels)
+        Lbry.apiCall(
+            method: Lbry.Methods.claimList,
+            params: .init(claimType: [.channel], page: 1, pageSize: 999)
+        )
+        .subscribeResult(didLoadChannels)
     }
     
     func didLoadChannels(_ result: Result<Page<Claim>, Error>) {

--- a/Odysee/Controllers/Library/GoLiveViewController.swift
+++ b/Odysee/Controllers/Library/GoLiveViewController.swift
@@ -221,9 +221,8 @@ class GoLiveViewController: UIViewController, UIPickerViewDataSource, UIPickerVi
                         claimType: [.channel],
                         page: 1,
                         pageSize: 999,
-                        resolve: true),
-                     authToken: Lbryio.authToken,
-                     completion: didLoadChannels)
+                        resolve: true))
+            .subscribeResult(didLoadChannels)
     }
     
     func canStreamOnChannel(_ channel: Claim?) -> Bool {

--- a/Odysee/Controllers/Library/PublishViewController.swift
+++ b/Odysee/Controllers/Library/PublishViewController.swift
@@ -118,8 +118,8 @@ class PublishViewController: UIViewController, UIGestureRecognizerDelegate, UIPi
                         claimType: [.stream],
                         page: 1,
                         pageSize: 999,
-                        resolve: true),
-                     completion: didLoadUploads)
+                        resolve: true))
+            .subscribeResult(didLoadUploads)
     }
     
     func didLoadUploads(_ result: Result<Page<Claim>, Error>) {
@@ -140,8 +140,8 @@ class PublishViewController: UIViewController, UIGestureRecognizerDelegate, UIPi
                      params: .init(claimType: [.channel],
                                    page: 1,
                                    pageSize: 999,
-                                   resolve: true),
-                     completion: didLoadChannels)
+                                   resolve: true))
+            .subscribeResult(didLoadChannels)
     }
     
     func didLoadChannels(_ result: Result<Page<Claim>, Error>) {

--- a/Odysee/Controllers/Library/PublishesViewController.swift
+++ b/Odysee/Controllers/Library/PublishesViewController.swift
@@ -72,8 +72,8 @@ class PublishesViewController: UIViewController, UITableViewDataSource, UITableV
                         claimType: [.stream],
                         page: currentPage,
                         pageSize: pageSize,
-                        resolve: true),
-                     completion: didReceiveUploads)
+                        resolve: true))
+            .subscribeResult(didReceiveUploads)
     }
     
 
@@ -112,8 +112,8 @@ class PublishesViewController: UIViewController, UITableViewDataSource, UITableV
                      params: .init(
                         claimId: claim.claimId!,
                         blocking: true
-                     ),
-                     completion: didAbandonClaim)
+                     ))
+            .subscribeResult(didAbandonClaim)
     }
     
     func didAbandonClaim(_ result: Result<Transaction, Error>) {

--- a/Odysee/Controllers/MainViewController.swift
+++ b/Odysee/Controllers/MainViewController.swift
@@ -109,7 +109,7 @@ class MainViewController: UIViewController, AVPlayerViewControllerDelegate {
         if !emailRewardClaimed {
             let receiveAddress = defaults.string(forKey: Helper.keyReceiveAddress)
             if ((receiveAddress ?? "").isBlank) {
-                Lbry.apiCall(method: Lbry.Methods.addressUnused, params: .init()) { result in
+                Lbry.apiCall(method: Lbry.Methods.addressUnused, params: .init()).subscribeResult { result in
                     guard case let .success(newAddress) = result else {
                         return
                     }
@@ -544,8 +544,8 @@ class MainViewController: UIViewController, AVPlayerViewControllerDelegate {
                         claimType: [.channel],
                         page: 1,
                         pageSize: 999,
-                        resolve: true),
-                     completion: didLoadChannels)
+                        resolve: true))
+            .subscribeResult(didLoadChannels)
     }
     
     func didLoadChannels(_ result: Result<Page<Claim>, Error>) {

--- a/Odysee/Controllers/User/NotificationsViewController.swift
+++ b/Odysee/Controllers/User/NotificationsViewController.swift
@@ -207,8 +207,8 @@ class NotificationsViewController: UIViewController, UIGestureRecognizerDelegate
         Lbry.apiCall(method: Lbry.Methods.resolve,
                      params: .init(
                         urls: notifications.filter { !($0.author ?? "").isBlank }.map { $0.author! }
-                     ),
-                     completion: didResolveCommentAuthors)
+                     ))
+            .subscribeResult(didResolveCommentAuthors)
     }
     
     func didResolveCommentAuthors(_ result: Result<ResolveResult, Error>) {

--- a/Odysee/Controllers/Wallet/RewardsViewController.swift
+++ b/Odysee/Controllers/Wallet/RewardsViewController.swift
@@ -548,7 +548,7 @@ class RewardsViewController: UIViewController, SFSafariViewControllerDelegate, S
         let defaults = UserDefaults.standard
         let receiveAddress = defaults.string(forKey: Helper.keyReceiveAddress)
         if ((receiveAddress ?? "").isBlank) {
-            Lbry.apiCall(method: Lbry.Methods.addressUnused, params: .init()) { result in
+            Lbry.apiCall(method: Lbry.Methods.addressUnused, params: .init()).subscribeResult { result in
                 guard case let .success(newAddress) = result else {
                     self.claimRewardFinished()
                     self.showError(message: String.localized("Could not obtain the wallet address for receiving rewards."))
@@ -570,10 +570,10 @@ class RewardsViewController: UIViewController, SFSafariViewControllerDelegate, S
                             claimType: [reward.rewardType == Reward.typeFirstPublish ? .stream : .channel],
                             page: 1,
                             pageSize: 1,
-                            resolve: true),
-                         completion: {
-                            self.didResolveRewardClaim($0, reward: reward, walletAddress: walletAddress)
-                         })
+                            resolve: true))
+                .subscribeResult {
+                    self.didResolveRewardClaim($0, reward: reward, walletAddress: walletAddress)
+                }
         } else {
             doClaimReward(reward, walletAddress: walletAddress, transactionId: nil)
         }

--- a/Odysee/Controllers/Wallet/TransactionsViewController.swift
+++ b/Odysee/Controllers/Wallet/TransactionsViewController.swift
@@ -62,8 +62,8 @@ class TransactionsViewController: UIViewController, UITableViewDataSource, UITab
         Lbry.apiCall(method: Lbry.Methods.transactionList,
                      params: .init(
                         page: currentPage,
-                        pageSize: pageSize),
-                     completion: didLoadTransactions)
+                        pageSize: pageSize))
+            .subscribeResult(didLoadTransactions)
     }
     
     func didLoadTransactions(_ result: Result<Page<Transaction>, Error>) {

--- a/Odysee/Controllers/Wallet/WalletViewController.swift
+++ b/Odysee/Controllers/Wallet/WalletViewController.swift
@@ -191,7 +191,7 @@ class WalletViewController: UIViewController, UITableViewDelegate, UITableViewDa
         
     func getNewReceiveAddress() {
         //getNewAddressButton.isEnabled = false
-        Lbry.apiCall(method: Lbry.Methods.addressUnused, params: .init()) { result in
+        Lbry.apiCall(method: Lbry.Methods.addressUnused, params: .init()).subscribeResult { result in
             guard case let .success(address) = result else {
                 result.showErrorIfPresent()
                 return
@@ -278,8 +278,8 @@ class WalletViewController: UIViewController, UITableViewDelegate, UITableViewDa
         Lbry.apiCall(method: Lbry.Methods.transactionList,
                      params: .init(
                         page: 1,
-                        pageSize: 5),
-                     completion: didLoadRecentTransactions)
+                        pageSize: 5))
+            .subscribeResult(didLoadRecentTransactions)
     }
     
     func didLoadRecentTransactions(_ result: Result<Page<Transaction>, Error>) {

--- a/Odysee/Utils/Extensions.swift
+++ b/Odysee/Utils/Extensions.swift
@@ -5,6 +5,7 @@
 //  Created by Akinwale Ariwodola on 06/11/2020.
 //
 
+import Combine
 import Foundation
 import PINRemoteImage
 import UIKit
@@ -190,5 +191,20 @@ extension Thread {
         } else {
             DispatchQueue.main.async(execute: f)
         }
+    }
+}
+
+extension Publisher {
+    // A convenience function to hook up a completion block that takes a Result to a publisher
+    // that is expected to publish only one value, or fail. For example, an API call.
+    func subscribeResult(_ f: @escaping (Result<Output, Failure>) -> Void) {
+        subscribe(
+            Subscribers.Sink(receiveCompletion: {
+                if case let .failure(error) = $0 {
+                    f(.failure(error))
+                }
+            }, receiveValue: {
+                f(.success($0))
+            }))
     }
 }


### PR DESCRIPTION
This is more boilerplate, but the Combine framework opens the door to a lot more interesting functionality.

For example, we can chain async operations (e.g. calling Lbryio then calling Lbry) and we can automatically bind loading operations to loading states in the UI etc.

Better to do the migration now than later.