### PR TITLE
Refactor remote request methods to be more Swift-friendly

### DIFF
--- a/Odysee/Controllers/Channel/ChannelViewController.swift
+++ b/Odysee/Controllers/Channel/ChannelViewController.swift
@@ -298,7 +298,7 @@ class ChannelViewController: UIViewController, UIGestureRecognizerDelegate, UISc
     func loadAndDisplayFollowerCount() {
         var options = Dictionary<String, String>()
         options["claim_id"] = channelClaim?.claimId
-        try! Lbryio.call(resource: "subscription", action: "sub_count", options: options, method: Lbryio.methodGet, completion: { data, error in
+        try! Lbryio.get(resource: "subscription", action: "sub_count", options: options, completion: { data, error in
             guard let data = data, error == nil else {
                 return
             }
@@ -658,7 +658,7 @@ class ChannelViewController: UIViewController, UIGestureRecognizerDelegate, UISc
             }
             
             let subUrl: LbryUri = try LbryUri.parse(url: (claim?.permanentUrl!)!, requireProto: false)
-            try Lbryio.call(resource: "subscription", action: unsubscribing ? "delete" : "new", options: options, method: Lbryio.methodGet, completion: { data, error in
+            try Lbryio.get(resource: "subscription", action: unsubscribing ? "delete" : "new", options: options, completion: { data, error in
                 self.subscribeUnsubscribeInProgress = false
                 guard let _ = data, error == nil else {
                     //print(error)

--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -783,7 +783,7 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
         }
         
         do {
-            try Lbryio.call(resource: "file", action: "view", options: options, method: Lbryio.methodPost, completion: { data, error in
+            try Lbryio.post(resource: "file", action: "view", options: options, completion: { data, error in
                 // no need to check for errors here
                 self.loggingInProgress = false
                 self.fileViewLogged = true
@@ -832,8 +832,7 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
         }
         
         do {
-            let options: Dictionary<String, String> = ["claim_id": singleClaim.claimId!]
-            try Lbryio.call(resource: "file", action: "view_count", options: options, method: Lbryio.methodGet, completion: { data, error in
+            try Lbryio.get(resource: "file", action: "view_count", options: ["claim_id": singleClaim.claimId!], completion: { data, error in
                 guard let data = data, error == nil else {
                     // couldn't load the view count for display
                     DispatchQueue.main.async {
@@ -861,7 +860,7 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
         do {
             let claimId = singleClaim.claimId!
             let options: Dictionary<String, String> = ["claim_ids": claimId]
-            try Lbryio.call(resource: "reaction", action: "list", options: options, method: Lbryio.methodPost, completion: { data, error in
+            try Lbryio.post(resource: "reaction", action: "list", options: options, completion: { data, error in
                 guard let data = data, error == nil else {
                     return
                 }
@@ -927,7 +926,7 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
                 remove = true
                 options["remove"] = "true"
             }
-            try Lbryio.call(resource: "reaction", action: "react", options: options, method: Lbryio.methodPost, completion: { data, error in
+            try Lbryio.post(resource: "reaction", action: "react", options: options, completion: { data, error in
                 guard let _ = data, error == nil else {
                     self.showError(error: error)
                     return
@@ -1373,7 +1372,7 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
             }
             
             let subUrl: LbryUri = try LbryUri.parse(url: (claim?.permanentUrl!)!, requireProto: false)
-            try Lbryio.call(resource: "subscription", action: unsubscribing ? "delete" : "new", options: options, method: Lbryio.methodGet, completion: { data, error in
+            try Lbryio.get(resource: "subscription", action: unsubscribing ? "delete" : "new", options: options, completion: { data, error in
                 self.subscribeUnsubscribeInProgress = false
                 guard let _ = data, error == nil else {
                     self.showError(error: error)

--- a/Odysee/Controllers/Content/FollowingViewController.swift
+++ b/Odysee/Controllers/Content/FollowingViewController.swift
@@ -162,7 +162,7 @@ class FollowingViewController: UIViewController, UICollectionViewDataSource, UIC
         }
         
         do {
-            try Lbryio.call(resource: "subscription", action: "list", options: nil, method: Lbryio.methodGet, completion: { data, error in
+            try Lbryio.get(resource: "subscription", action: "list", completion: { data, error in
                 guard let data = data, error == nil else {
                     print(error!)
                     return
@@ -444,7 +444,7 @@ class FollowingViewController: UIViewController, UICollectionViewDataSource, UIC
             }
             
             let subUrl: LbryUri = try LbryUri.parse(url: (claim?.permanentUrl!)!, requireProto: false)
-            try Lbryio.call(resource: "subscription", action: unsubscribing ? "delete" : "new", options: options, method: Lbryio.methodGet, completion: { data, error in
+            try Lbryio.get(resource: "subscription", action: unsubscribing ? "delete" : "new", options: options, completion: { data, error in
                 guard let _ = data, error == nil else {
                     print(error!)
                     return

--- a/Odysee/Controllers/InitViewController.swift
+++ b/Odysee/Controllers/InitViewController.swift
@@ -93,7 +93,7 @@ class InitViewController: UIViewController {
             loadLocalSubscriptions()
             
             // check if there are remote subscriptions and load them too
-            try Lbryio.call(resource: "subscription", action: "list", options: nil, method: Lbryio.methodGet, completion: { data, error in
+            try Lbryio.get(resource: "subscription", action: "list", completion: { data, error in
                 guard let data = data, error == nil else {
                     self.authenticateAndRegisterInstall()
                     return

--- a/Odysee/Controllers/MainViewController.swift
+++ b/Odysee/Controllers/MainViewController.swift
@@ -287,7 +287,7 @@ class MainViewController: UIViewController, AVPlayerViewControllerDelegate {
     
     func loadFilteredOutpoints() {
         do {
-            try Lbryio.call(resource: "file", action: "list_filtered", options: [:], method: Lbryio.methodGet, completion: { data, error in
+            try Lbryio.get(resource: "file", action: "list_filtered", options: [:], completion: { data, error in
                 guard let data = data, error == nil else {
                     return
                 }
@@ -305,7 +305,7 @@ class MainViewController: UIViewController, AVPlayerViewControllerDelegate {
     
     func loadBlockedOutpoints() {
         do {
-            try Lbryio.call(resource: "file", action: "list_blocked", options: [:], method: Lbryio.methodGet, completion: { data, error in
+            try Lbryio.get(resource: "file", action: "list_blocked", options: [:], completion: { data, error in
                 guard let data = data, error == nil else {
                     return
                 }
@@ -332,7 +332,7 @@ class MainViewController: UIViewController, AVPlayerViewControllerDelegate {
                 options["since_id"] = String(Lbryio.latestNotificationId)
             }
             
-            try Lbryio.call(resource: "notification", action: "list", options: options, method: Lbryio.methodPost, completion: { data, error in
+            try Lbryio.post(resource: "notification", action: "list", options: options, completion: { data, error in
                 guard let data = data, error == nil else {
                     return
                 }

--- a/Odysee/Controllers/User/NotificationsViewController.swift
+++ b/Odysee/Controllers/User/NotificationsViewController.swift
@@ -90,7 +90,7 @@ class NotificationsViewController: UIViewController, UIGestureRecognizerDelegate
             options["notification_ids"] = seenIds.map { String($0) }.joined(separator: ",");
             options["is_seen"] = "true"
             do {
-                try Lbryio.call(resource: "notification", action: "edit", options: options, method: Lbryio.methodPost, completion: { data, error in
+                try Lbryio.post(resource: "notification", action: "edit", options: options, completion: { data, error in
                     guard let _ = data, error == nil else {
                         return
                     }
@@ -115,7 +115,7 @@ class NotificationsViewController: UIViewController, UIGestureRecognizerDelegate
             options["is_seen"] = "true"
             options["is_read"] = "true"
             do {
-                try Lbryio.call(resource: "notification", action: "edit", options: options, method: Lbryio.methodPost, completion: { data, error in
+                try Lbryio.post(resource: "notification", action: "edit", options: options, completion: { data, error in
                     guard let _ = data, error == nil else {
                         return
                     }
@@ -130,7 +130,7 @@ class NotificationsViewController: UIViewController, UIGestureRecognizerDelegate
         var options: Dictionary<String, String> = [:]
         options["notification_ids"] = String(id)
         do {
-            try Lbryio.call(resource: "notification", action: "delete", options: options, method: Lbryio.methodPost, completion: { data, error in
+            try Lbryio.post(resource: "notification", action: "delete", options: options, completion: { data, error in
                 guard let _ = data, error == nil else {
                     return
                 }
@@ -159,7 +159,7 @@ class NotificationsViewController: UIViewController, UIGestureRecognizerDelegate
             if Lbryio.latestNotificationId > 0 {
                 options["since_id"] = String(Lbryio.latestNotificationId)
             }
-            try Lbryio.call(resource: "notification", action: "list", options: options, method: Lbryio.methodPost, completion: { data, error in
+            try Lbryio.post(resource: "notification", action: "list", options: options, completion: { data, error in
                 guard let data = data, error == nil else {
                     DispatchQueue.main.async {
                         self.loadingContainer.isHidden = true

--- a/Odysee/Controllers/User/UserAccountViewController.swift
+++ b/Odysee/Controllers/User/UserAccountViewController.swift
@@ -151,7 +151,7 @@ class UserAccountViewController: UIViewController {
             var options = Dictionary<String, String>()
             options["email"] = email
             options["password"] = password
-            try Lbryio.call(resource: "user", action: "signup", options: options, method: Lbryio.methodPost, completion: { data, error in
+            try Lbryio.post(resource: "user", action: "signup", options: options, completion: { data, error in
                 DispatchQueue.main.async {
                     self.defaultActionButton.isEnabled = true
                 }
@@ -296,7 +296,7 @@ class UserAccountViewController: UIViewController {
                 self.frDelegate?.requestStarted()
                 var options = Dictionary<String, String>()
                 options["email"] = email
-                try Lbryio.call(resource: "user", action: "exists", options: options, method: Lbryio.methodPost, completion: { data, error in
+                try Lbryio.post(resource: "user", action: "exists", options: options, completion: { data, error in
                     guard let data = data, error == nil else {
                         if let responseError = error as? LbryioResponseError {
                             if responseError.code == 412 {
@@ -361,7 +361,7 @@ class UserAccountViewController: UIViewController {
         do {
             self.requestInProgress = true
             self.frDelegate?.requestStarted()
-            try Lbryio.call(resource: "user", action: "signin", options: options, method: Lbryio.methodPost, completion: { data, error in
+            try Lbryio.post(resource: "user", action: "signin", options: options, completion: { data, error in
                 DispatchQueue.main.async {
                     self.defaultActionButton.isEnabled = true
                 }
@@ -416,7 +416,7 @@ class UserAccountViewController: UIViewController {
             var options = Dictionary<String, String>()
             options["email"] = email
             options["only_if_expired"] = "true"
-            try Lbryio.call(resource: "user_email", action: "resend_token", options: options, method: Lbryio.methodPost, completion: { data, error in
+            try Lbryio.post(resource: "user_email", action: "resend_token", options: options, completion: { data, error in
                 guard let _ = data, error == nil else {
                     self.showError(error: error)
                     return
@@ -434,7 +434,7 @@ class UserAccountViewController: UIViewController {
             var options = Dictionary<String, String>()
             options["email"] = email
             options["send_verification_email"] = "true"
-            try Lbryio.call(resource: "user_email", action: "new", options: options, method: Lbryio.methodPost, completion: { data, error in
+            try Lbryio.post(resource: "user_email", action: "new", options: options, completion: { data, error in
                 guard let _ = data, error == nil else {
                     if let responseError = error as? LbryioResponseError {
                         if responseError.code == 409 {

--- a/Odysee/Controllers/User/YouTubeSyncStatusViewController.swift
+++ b/Odysee/Controllers/User/YouTubeSyncStatusViewController.swift
@@ -102,7 +102,7 @@ class YouTubeSyncStatusViewController: UIViewController {
     func transferChannel(address: String, publicKey: String) {
         do {
             let options = ["address": address, "public_key": publicKey]
-            try Lbryio.call(resource: "yt", action: "transfer", options: options, method: Lbryio.methodPost, completion: { data, error in
+            try Lbryio.post(resource: "yt", action: "transfer", options: options, completion: { data, error in
                 guard let data = data, error == nil else {
                     self.showError(error: error)
                     self.restoreButtons()
@@ -161,7 +161,7 @@ class YouTubeSyncStatusViewController: UIViewController {
             claimChannelButton.isHidden = true
             exploreOdyseeButton.isHidden = true
             loadingIndicator.isHidden = false
-            try Lbryio.call(resource: "yt", action: "transfer", options: [:], method: Lbryio.methodPost, completion: { data, error in
+            try Lbryio.post(resource: "yt", action: "transfer", options: [:], completion: { data, error in
                 guard let data = data, error == nil else {
                     //self.showError(error: error)
                     self.restoreButtons()

--- a/Odysee/Controllers/User/YouTubeSyncViewController.swift
+++ b/Odysee/Controllers/User/YouTubeSyncViewController.swift
@@ -93,7 +93,7 @@ class YouTubeSyncViewController: UIViewController, WKNavigationDelegate {
                 "desired_lbry_channel_name": channelName,
                 "return_url": returnUrl
             ]
-            try Lbryio.call(resource: "yt", action: "new", options: options, method: Lbryio.methodPost, completion: { data, error in
+            try Lbryio.post(resource: "yt", action: "new", options: options, completion: { data, error in
                 guard let data = data, error == nil else {
                     self.showError(error: error)
                     self.restoreButtons()

--- a/Odysee/Controllers/Wallet/RewardsViewController.swift
+++ b/Odysee/Controllers/Wallet/RewardsViewController.swift
@@ -170,7 +170,7 @@ class RewardsViewController: UIViewController, SFSafariViewControllerDelegate, S
         }
         
         do {
-            try Lbryio.call(resource: "reward", action: "list", options: ["multiple_rewards_per_type": "true"], method: Lbryio.methodGet, completion: { data, error in
+            try Lbryio.get(resource: "reward", action: "list", options: ["multiple_rewards_per_type": "true"], completion: { data, error in
                 guard let data = data, error == nil else {
                     DispatchQueue.main.async {
                         self.loadingContainer.isHidden = true
@@ -342,7 +342,7 @@ class RewardsViewController: UIViewController, SFSafariViewControllerDelegate, S
             "domain": "odysee.com"
         ]
         do {
-            try Lbryio.call(resource: "verification", action: "twitter_verify", options: options, method: Lbryio.methodPost, completion: { data, error in
+            try Lbryio.post(resource: "verification", action: "twitter_verify", options: options, completion: { data, error in
                 guard let data = data, error == nil else {
                     self.stopProcessing()
                     self.showError(error: error)
@@ -413,7 +413,7 @@ class RewardsViewController: UIViewController, SFSafariViewControllerDelegate, S
                 let base64ReceiptString = receiptData.base64EncodedString(options: [])
              
                 let options: Dictionary<String, String> = ["receipt": base64ReceiptString]
-                try Lbryio.call(resource: "verification", action: "ios_purchase", options: options, method: Lbryio.methodPost, completion: { data, error in
+                try Lbryio.post(resource: "verification", action: "ios_purchase", options: options, completion: { data, error in
                     guard let data = data, error == nil else {
                         completion(nil, error)
                         return
@@ -604,7 +604,7 @@ class RewardsViewController: UIViewController, SFSafariViewControllerDelegate, S
         }
         
         do {
-            try Lbryio.call(resource: "reward", action: "claim", options: options, method: Lbryio.methodPost, completion: { data, error in
+            try Lbryio.post(resource: "reward", action: "claim", options: options, completion: { data, error in
                 guard let data = data, error == nil else {
                     self.claimRewardFinished()
                     self.showError(error: error)


### PR DESCRIPTION
Refactor the common Lbryio remote request methods ("GET" and "POST") to a more Swift-y approach using a String-backed enum and verb-oriented functions (.get and .post). This approach is intended to eliminate possible typo errors when making requests, reduces the overall number of arguments and mental overhead for making a request, and makes request support more formalized and easier to search and understand from auto-complete or other IDE support. Since there is no functionality change, only code organization, no changes to tests or other major validation is suspected to be required.