### PR TITLE
Refactor the way UserDefaults are handled for the Lbryio module

### DIFF
--- a/Odysee/Controllers/InitViewController.swift
+++ b/Odysee/Controllers/InitViewController.swift
@@ -28,7 +28,7 @@ class InitViewController: UIViewController {
             defaults.set(Lbry.installationId, forKey: Lbry.keyInstallationId)
         }
         
-        Lbryio.authToken = defaults.string(forKey: Lbryio.keyAuthToken)
+        Lbryio.authToken = Lbryio.Defaults.authToken
         
         Lbryio.loadExchangeRate(completion: { rate, error in
             // don't bother with error checks here, simply proceed to authenticate

--- a/Odysee/Controllers/User/UserAccountMenuViewController.swift
+++ b/Odysee/Controllers/User/UserAccountMenuViewController.swift
@@ -93,20 +93,16 @@ class UserAccountMenuViewController: UIViewController {
     }
     
     @IBAction func youTubeSyncTapped(_ sender: Any) {
-        let defaults = UserDefaults.standard
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
         
         var vc: UIViewController!
-        let ytSyncConnected = defaults.bool(forKey: Lbryio.keyYouTubeSyncConnected)
-        if ytSyncConnected {
+        if Lbryio.Defaults.isYouTubeSyncConnected {
             vc = self.storyboard?.instantiateViewController(identifier: "yt_sync_status_vc") as! YouTubeSyncStatusViewController
         } else {
             vc = self.storyboard?.instantiateViewController(identifier: "yt_sync_vc") as! YouTubeSyncViewController
         }
         appDelegate.mainNavigationController?.pushViewController(vc, animated: true)
         presentingViewController?.dismiss(animated: false, completion: nil)
-        
-        
     }
     
     @IBAction func communityGuidelinesTapped(_ sender: Any) {

--- a/Odysee/Controllers/User/UserAccountViewController.swift
+++ b/Odysee/Controllers/User/UserAccountViewController.swift
@@ -466,11 +466,9 @@ class UserAccountViewController: UIViewController {
         passwordField.text = ""
         Lbryio.authToken = nil
         
-        let defaults = UserDefaults.standard
-        defaults.removeObject(forKey: Lbryio.keyAuthToken)
-        defaults.removeObject(forKey: Lbryio.keyYouTubeSyncDone)
-        defaults.removeObject(forKey: Lbryio.keyYouTubeSyncConnected)
-        defaults.removeObject(forKey: Helper.keyReceiveAddress)
+        Lbryio.Defaults.reset()
+        
+        UserDefaults.standard.removeObject(forKey: Helper.keyReceiveAddress)
         
         controlsStackView.isHidden = false
         haveAccountLabel.isHidden = false

--- a/Odysee/Controllers/User/YouTubeSyncViewController.swift
+++ b/Odysee/Controllers/User/YouTubeSyncViewController.swift
@@ -174,14 +174,13 @@ class YouTubeSyncViewController: UIViewController, WKNavigationDelegate {
     }
     
     func finishYouTubeSync(ytSyncConnected: Bool) {
-        let defaults = UserDefaults.standard
-        defaults.setValue(true, forKey: Lbryio.keyYouTubeSyncDone)
-        defaults.setValue(ytSyncConnected, forKey: Lbryio.keyYouTubeSyncConnected)
+        Lbryio.Defaults.isYouTubeSyncDone = true
+        Lbryio.Defaults.isYouTubeSyncConnected = ytSyncConnected
         
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
         appDelegate.mainNavigationController?.popViewController(animated: true)
         if (ytSyncConnected) {
-            // redirect to YouTube Sync Status page
+            // TODO: redirect to YouTube Sync Status page
         }
     }
 

--- a/Odysee/Controllers/Wallet/WalletSyncViewController.swift
+++ b/Odysee/Controllers/Wallet/WalletSyncViewController.swift
@@ -163,14 +163,11 @@ class WalletSyncViewController: UIViewController {
         if (popViewController) {
             appDelegate.mainNavigationController?.popViewController(animated: false)
         }
-        
-        
-        let defaults = UserDefaults.standard
-        let ytSyncDone = defaults.bool(forKey: Lbryio.keyYouTubeSyncDone)
-        if !ytSyncDone {
-            let vc = self.storyboard?.instantiateViewController(identifier: "yt_sync_vc") as! YouTubeSyncViewController
-            appDelegate.mainNavigationController?.pushViewController(vc, animated: true)
+        guard !(Lbryio.Defaults.isYouTubeSyncDone) else {
+            return
         }
+        let vc = self.storyboard?.instantiateViewController(identifier: "yt_sync_vc") as! YouTubeSyncViewController
+        appDelegate.mainNavigationController?.pushViewController(vc, animated: true)
     }
     
     func requestSyncApplyWithPassword() {

--- a/Odysee/Utils/Lbryio.swift
+++ b/Odysee/Utils/Lbryio.swift
@@ -13,6 +13,83 @@ final class Lbryio {
     static let methodGet = "GET"
     static let methodPost = "POST"
     
+    final class Defaults {
+        private enum Key : String {
+            case AuthToken
+            case ChannelsAssociated
+            case EmailRewardClaimed
+            case YouTubeSyncConnected
+            case YouTubeSyncDone
+        }
+        
+        private static func get(string: Key) -> String? {
+            return UserDefaults.standard.string(forKey: string.rawValue)
+        }
+        private static func set(string: Key, value: String?) {
+            UserDefaults.standard.set(value, forKey: string.rawValue)
+        }
+        
+        private static func get(bool: Key) -> Bool {
+            return UserDefaults.standard.bool(forKey: bool.rawValue)
+        }
+        private static func set(bool: Key, value: Bool) {
+            UserDefaults.standard.set(value, forKey: bool.rawValue)
+        }
+        
+        static var authToken: String? {
+            get {
+                return get(string: .AuthToken)
+            }
+            set {
+                set(string: .AuthToken, value: newValue)
+            }
+        }
+        
+        static var isEmailRewardClaimed: Bool {
+            get {
+                return get(bool: .EmailRewardClaimed)
+            }
+            set {
+                set(bool: .EmailRewardClaimed, value: newValue)
+            }
+        }
+        
+        static var isChannelsAssociated: Bool {
+            get {
+                return get(bool: .ChannelsAssociated)
+            }
+            set {
+                set(bool: .ChannelsAssociated, value: newValue)
+            }
+        }
+        
+        static var isYouTubeSyncConnected: Bool {
+            get {
+                return get(bool: .YouTubeSyncConnected)
+            }
+            set {
+                set(bool: .YouTubeSyncConnected, value: newValue)
+            }
+        }
+        
+        static var isYouTubeSyncDone: Bool {
+            get {
+                return get(bool: .YouTubeSyncDone)
+            }
+            set {
+                set(bool: .YouTubeSyncDone, value: newValue)
+            }
+        }
+        
+        static func reset() {
+            let defaults = UserDefaults.standard
+            defaults.removeObject(forKey: Lbryio.Defaults.Key.AuthToken.rawValue)
+            defaults.removeObject(forKey: Lbryio.Defaults.Key.EmailRewardClaimed.rawValue)
+            defaults.removeObject(forKey: Lbryio.Defaults.Key.YouTubeSyncDone.rawValue)
+            defaults.removeObject(forKey: Lbryio.Defaults.Key.YouTubeSyncConnected.rawValue)
+        }
+    }
+    
     static var generatingAuthToken: Bool = false
     static let connectionString = "https://api.lbry.com"
     static let commentronUrl = "https://comments.lbry.com/api/v2"
@@ -21,12 +98,6 @@ final class Lbryio {
     static let authTokenParam = "auth_token"
     static var authToken: String? = nil
     
-    static let keyEmailRewardClaimed: String = "EmailRewardClaimed"
-    static let keyYouTubeSyncDone: String = "YouTubeSyncDone"
-    static let keyYouTubeSyncConnected: String = "YouTubeSyncConnected"
-    static let keyChannelsAssociated: String = "ChannelsAssociated"
-    
-    static let keyAuthToken = "AuthToken"
     static var currentUser: User? = nil
     
     private static let lock = Lock()
@@ -59,8 +130,7 @@ final class Lbryio {
                     Lbryio.authToken = token
                     
                     // Persist the token
-                    let defaults = UserDefaults.standard
-                    defaults.set(token, forKey: keyAuthToken)
+                    Defaults.authToken = token
                 }
                 
                 // send the call after the auth token has been retrieved


### PR DESCRIPTION
Refactor the way UserDefaults are handled for the Lbryio module. Specifically, hide the details of how the defaults are being persisted, what keys are used, and provide a much simpler var-based interface to fetch and update the defaults. This is intended to reduce potential typo issues with keys, enforce strong type boundaries for default values, and hide away details such that these defaults can be stored anywhere as long as their behavior is consistent. These changes are simply reorganization, so no major testing or behavior changes are expected.