### PR TITLE
[#136] Hide the header view on all sub-menus to mitigate nav issues

### DIFF
--- a/Odysee/Controllers/Channel/ChannelEditorViewController.swift
+++ b/Odysee/Controllers/Channel/ChannelEditorViewController.swift
@@ -44,15 +44,13 @@ class ChannelEditorViewController: UIViewController, UITextFieldDelegate, UIGest
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        appDelegate.mainController.toggleHeaderVisibility(hidden: true)
         appDelegate.mainController.adjustMiniPlayerBottom(bottom: Helper.miniPlayerBottomWithoutTabBar())
     }
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         Analytics.logEvent(AnalyticsEventScreenView, parameters: [AnalyticsParameterScreenName: "ChannelForm", AnalyticsParameterScreenClass: "ChannelEditorViewController"])
-        
-        let appDelegate = UIApplication.shared.delegate as! AppDelegate
-        appDelegate.mainController.toggleHeaderVisibility(hidden: false)
         
         self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
         self.navigationController?.interactivePopGestureRecognizer?.delegate = self

--- a/Odysee/Controllers/Channel/ChannelManagerViewController.swift
+++ b/Odysee/Controllers/Channel/ChannelManagerViewController.swift
@@ -23,6 +23,7 @@ class ChannelManagerViewController: UIViewController, UITableViewDelegate, UITab
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        appDelegate.mainController.toggleHeaderVisibility(hidden: true)
         appDelegate.mainController.adjustMiniPlayerBottom(bottom: Helper.miniPlayerBottomWithoutTabBar())
     }
     
@@ -31,7 +32,6 @@ class ChannelManagerViewController: UIViewController, UITableViewDelegate, UITab
         Analytics.logEvent(AnalyticsEventScreenView, parameters: [AnalyticsParameterScreenName: "Channels", AnalyticsParameterScreenClass: "ChannelManagerViewController"])
         
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
-        appDelegate.mainController.toggleHeaderVisibility(hidden: false)
         
         self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
         self.navigationController?.interactivePopGestureRecognizer?.delegate = self

--- a/Odysee/Controllers/Library/PublishViewController.swift
+++ b/Odysee/Controllers/Library/PublishViewController.swift
@@ -50,6 +50,12 @@ class PublishViewController: UIViewController, UIGestureRecognizerDelegate, UIPi
     
     let namePrefixFormat = "odysee.com/%@"
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        appDelegate.mainController.toggleHeaderVisibility(hidden: true)
+    }
+    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         Analytics.logEvent(AnalyticsEventScreenView, parameters: [AnalyticsParameterScreenName: "PublishForm", AnalyticsParameterScreenClass: "PublishViewController"])

--- a/Odysee/Controllers/Wallet/RewardsViewController.swift
+++ b/Odysee/Controllers/Wallet/RewardsViewController.swift
@@ -51,6 +51,7 @@ class RewardsViewController: UIViewController, SFSafariViewControllerDelegate, S
     
     override func viewWillAppear(_ animated: Bool) {
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        appDelegate.mainController.toggleHeaderVisibility(hidden: true)
         appDelegate.mainController.adjustMiniPlayerBottom(bottom: Helper.miniPlayerBottomWithoutTabBar())
         
         if Lbryio.isSignedIn() {
@@ -141,10 +142,8 @@ class RewardsViewController: UIViewController, SFSafariViewControllerDelegate, S
     
     func showRewardsList() {
         DispatchQueue.main.async {
-            if !self.firstRunFlow {
-                let appDelegate = UIApplication.shared.delegate as! AppDelegate
-                appDelegate.mainController.toggleHeaderVisibility(hidden: false)
-            }
+            let appDelegate = UIApplication.shared.delegate as! AppDelegate
+            appDelegate.mainController.toggleHeaderVisibility(hidden: true)
                 
             self.rewardVerificationPathsView.isHidden = true
             self.closeVerificationButton.isHidden = true


### PR DESCRIPTION
[#136] Hide the header view on all sub-menus to prevent a lot of navigation issues such as redundant nav pushes, seemingly nothing happening when pressing the credits button, request crashes, etc.

The source of the perceived inaction in the #136 issue is actually that the main view controller is being updated, but the sub-menu view controller (such as the Channels view) covering it up on the navigation stack. Removing the ability to tap the top bar on all of these sub-menus solves a lot of the various navigation issues, even though the pop-in for the header looks pretty bad at the moment.

![Simulator Screen Shot - iPhone 8 - 2021-07-26 at 21 31 17](https://user-images.githubusercontent.com/1031501/127080546-ea01d1cf-d7a3-4ea0-b2f6-86f63bfca6fb.png)
![Simulator Screen Shot - iPhone 8 - 2021-07-26 at 21 31 30](https://user-images.githubusercontent.com/1031501/127080561-536d842f-9a96-4726-86cd-5e9864b800c5.png)
![Simulator Screen Shot - iPhone 8 - 2021-07-26 at 21 31 42](https://user-images.githubusercontent.com/1031501/127080575-0752b7f7-4f34-4c83-889d-ac7e100aeee2.png)
