### PR TITLE
[#6] Re-enable iPad support

### DIFF
--- a/Odysee.xcodeproj/project.pbxproj
+++ b/Odysee.xcodeproj/project.pbxproj
@@ -959,7 +959,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.odysee.Odysee;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -981,7 +981,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.odysee.Odysee;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/Odysee/Base.lproj/Main.storyboard
+++ b/Odysee/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="TO2-4r-AEp">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <device id="ipad10_2" orientation="landscape" layout="fullscreen" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
@@ -15,11 +15,11 @@
             <objects>
                 <viewController storyboardIdentifier="main_vc" id="NqH-oh-ggT" customClass="MainViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="35t-ER-wNy">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FKL-n0-nM7" userLabel="Header Area">
-                                <rect key="frame" x="0.0" y="44" width="414" height="52"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="52"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="brand" translatesAutoresizingMaskIntoConstraints="NO" id="XIb-I5-UZJ">
                                         <rect key="frame" x="16" y="2" width="90" height="48"/>
@@ -33,7 +33,7 @@
                                         </connections>
                                     </imageView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fxt-7F-NNa" userLabel="Header Actions">
-                                        <rect key="frame" x="226" y="0.0" width="188" height="52"/>
+                                        <rect key="frame" x="892" y="0.0" width="188" height="52"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Lld-oM-oWY" userLabel="Balance Button">
                                                 <rect key="frame" x="0.0" y="0.0" width="56" height="52"/>
@@ -196,13 +196,13 @@
                                 </constraints>
                             </view>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WdW-3H-xb0">
-                                <rect key="frame" x="0.0" y="96" width="414" height="800"/>
+                                <rect key="frame" x="0.0" y="52" width="1080" height="758"/>
                                 <connections>
                                     <segue destination="cAg-3U-Ca8" kind="embed" identifier="main_nav" id="dmd-Fz-d8L"/>
                                 </connections>
                             </containerView>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MkF-lQ-MQ4" userLabel="Mini Player View" customClass="UICardView" customModule="Odysee" customModuleProvider="target">
-                                <rect key="frame" x="2" y="721" width="410" height="90"/>
+                                <rect key="frame" x="2" y="635" width="1076" height="90"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GdG-4w-vOQ">
                                         <rect key="frame" x="0.0" y="0.0" width="160" height="90"/>
@@ -213,16 +213,16 @@
                                         </constraints>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="ZMe-Cs-ZmQ">
-                                        <rect key="frame" x="160" y="28" width="226" height="34.5"/>
+                                        <rect key="frame" x="160" y="28" width="892" height="34.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="07y-sU-PS6">
-                                                <rect key="frame" x="16" y="0.0" width="194" height="16"/>
+                                                <rect key="frame" x="16" y="0.0" width="860" height="16"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EkP-1M-Aqs">
-                                                <rect key="frame" x="16" y="20" width="194" height="14.5"/>
+                                                <rect key="frame" x="16" y="20" width="860" height="14.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -231,7 +231,7 @@
                                         <edgeInsets key="layoutMargins" top="0.0" left="16" bottom="0.0" right="16"/>
                                     </stackView>
                                     <imageView clipsSubviews="YES" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="sharp_close_black_24pt" translatesAutoresizingMaskIntoConstraints="NO" id="5Fw-oG-SwQ">
-                                        <rect key="frame" x="386" y="0.0" width="24" height="90"/>
+                                        <rect key="frame" x="1052" y="0.0" width="24" height="90"/>
                                         <color key="tintColor" systemColor="labelColor"/>
                                         <gestureRecognizers/>
                                         <constraints>
@@ -363,26 +363,26 @@
             <objects>
                 <viewController storyboardIdentifier="wallet_vc" id="RiP-bz-JKs" customClass="WalletViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="KLY-Jn-cVs">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="800"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="758"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XT5-Ft-Hxx">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="751"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="708"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="4eJ-8X-dlt">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="1707.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="1080" height="1707.5"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zjw-jt-fyT" userLabel="Balance Card View" customClass="UICardView" customModule="Odysee" customModuleProvider="target">
-                                                <rect key="frame" x="16" y="16" width="382" height="627.5"/>
+                                                <rect key="frame" x="16" y="16" width="1048" height="627.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Balance" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Svx-1t-cTC">
-                                                        <rect key="frame" x="16" y="16" width="60.5" height="19.5"/>
+                                                        <rect key="frame" x="16" y="16" width="60.5" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Atg-ph-KU2" userLabel="Balance View">
-                                                        <rect key="frame" x="16" y="43.5" width="350" height="35.5"/>
+                                                        <rect key="frame" x="16" y="58" width="350" height="35.5"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="credits_icon" translatesAutoresizingMaskIntoConstraints="NO" id="paj-UM-lgw">
                                                                 <rect key="frame" x="0.0" y="10" width="16" height="16"/>
@@ -409,26 +409,26 @@
                                                         </constraints>
                                                     </view>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="≈$0.00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ckl-l8-SSk">
-                                                        <rect key="frame" x="16" y="81" width="40.5" height="14.5"/>
+                                                        <rect key="frame" x="16" y="95.5" width="40.5" height="14.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your total balance. All of this is yours, but some may be in use on channels and content." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u33-7C-LEj">
-                                                        <rect key="frame" x="16" y="99.5" width="350" height="29"/>
+                                                        <rect key="frame" x="16" y="114" width="1016" height="14.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WI5-rc-pcE" userLabel="Divider">
-                                                        <rect key="frame" x="4" y="136.5" width="374" height="1"/>
+                                                        <rect key="frame" x="4" y="136.5" width="1040" height="1"/>
                                                         <color key="backgroundColor" systemColor="systemGray4Color"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="1" id="kmZ-Fi-UEv"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6La-nl-Cp1" userLabel="Immediately Spendable container">
-                                                        <rect key="frame" x="16" y="145.5" width="350" height="28"/>
+                                                        <rect key="frame" x="16" y="145.5" width="1016" height="28"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="credits_icon" translatesAutoresizingMaskIntoConstraints="NO" id="I8u-gO-mFI">
                                                                 <rect key="frame" x="0.0" y="8" width="12" height="12"/>
@@ -463,7 +463,7 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9eb-W1-AmE" userLabel="Boosting Content container">
-                                                        <rect key="frame" x="16" y="181.5" width="350" height="28"/>
+                                                        <rect key="frame" x="16" y="181.5" width="1016" height="28"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="credits_icon" translatesAutoresizingMaskIntoConstraints="NO" id="EFG-I8-Rq6">
                                                                 <rect key="frame" x="0.0" y="8" width="12" height="12"/>
@@ -510,10 +510,10 @@
                                                         </constraints>
                                                     </view>
                                                     <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="SUR-qK-4B4">
-                                                        <rect key="frame" x="16" y="217.5" width="350" height="402"/>
+                                                        <rect key="frame" x="16" y="217.5" width="1016" height="402"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JcS-Ei-Vja">
-                                                                <rect key="frame" x="0.0" y="0.0" width="350" height="128"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="1016" height="128"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="...earned from others" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QfQ-7P-M0d">
                                                                         <rect key="frame" x="0.0" y="4" width="110.5" height="120"/>
@@ -522,7 +522,7 @@
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="czg-g2-d3L" userLabel="Credits View">
-                                                                        <rect key="frame" x="330.5" y="0.0" width="19.5" height="128"/>
+                                                                        <rect key="frame" x="996.5" y="0.0" width="19.5" height="128"/>
                                                                         <subviews>
                                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="credits_icon" translatesAutoresizingMaskIntoConstraints="NO" id="f47-Qs-Eqi">
                                                                                 <rect key="frame" x="0.0" y="60" width="8" height="8"/>
@@ -561,14 +561,14 @@
                                                                 </constraints>
                                                             </view>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="klz-Nm-Nte" userLabel="Divider">
-                                                                <rect key="frame" x="0.0" y="132" width="350" height="1"/>
+                                                                <rect key="frame" x="0.0" y="132" width="1016" height="1"/>
                                                                 <color key="backgroundColor" systemColor="systemGray4Color"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="1" id="PYg-jE-EFG"/>
                                                                 </constraints>
                                                             </view>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZRK-UT-mJq">
-                                                                <rect key="frame" x="0.0" y="137" width="350" height="128"/>
+                                                                <rect key="frame" x="0.0" y="137" width="1016" height="128"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="...on initial publishes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="05q-sL-rvU">
                                                                         <rect key="frame" x="0.0" y="4" width="107.5" height="120"/>
@@ -577,7 +577,7 @@
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SSK-jS-5wv" userLabel="Credits View">
-                                                                        <rect key="frame" x="330.5" y="0.0" width="19.5" height="128"/>
+                                                                        <rect key="frame" x="996.5" y="0.0" width="19.5" height="128"/>
                                                                         <subviews>
                                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="credits_icon" translatesAutoresizingMaskIntoConstraints="NO" id="WwN-2i-YbT">
                                                                                 <rect key="frame" x="0.0" y="60" width="8" height="8"/>
@@ -617,14 +617,14 @@
                                                                 </constraints>
                                                             </view>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kGb-ie-lhv" userLabel="Divider">
-                                                                <rect key="frame" x="0.0" y="269" width="350" height="1"/>
+                                                                <rect key="frame" x="0.0" y="269" width="1016" height="1"/>
                                                                 <color key="backgroundColor" systemColor="systemGray4Color"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="1" id="V3H-Bo-AgV"/>
                                                                 </constraints>
                                                             </view>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jNc-d5-OCu">
-                                                                <rect key="frame" x="0.0" y="274" width="350" height="128"/>
+                                                                <rect key="frame" x="0.0" y="274" width="1016" height="128"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="...on supporting content" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OT6-tc-O1O">
                                                                         <rect key="frame" x="0.0" y="4" width="126.5" height="120"/>
@@ -633,7 +633,7 @@
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ogh-R6-Il8" userLabel="Credits View">
-                                                                        <rect key="frame" x="330.5" y="0.0" width="19.5" height="128"/>
+                                                                        <rect key="frame" x="996.5" y="0.0" width="19.5" height="128"/>
                                                                         <subviews>
                                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="credits_icon" translatesAutoresizingMaskIntoConstraints="NO" id="MYR-iL-U99">
                                                                                 <rect key="frame" x="0.0" y="60" width="8" height="8"/>
@@ -702,7 +702,7 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UDD-GS-mUD" userLabel="Receive Card View" customClass="UICardView" customModule="Odysee" customModuleProvider="target">
-                                                <rect key="frame" x="16" y="659.5" width="382" height="165"/>
+                                                <rect key="frame" x="16" y="659.5" width="1048" height="165"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Receive" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="doV-w1-h0u">
                                                         <rect key="frame" x="16" y="16" width="59.5" height="19.5"/>
@@ -717,7 +717,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="axe-PG-cKK">
-                                                        <rect key="frame" x="16" y="78" width="350" height="71"/>
+                                                        <rect key="frame" x="16" y="78" width="1016" height="71"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits"/>
                                                         <connections>
@@ -740,7 +740,7 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ynr-Bo-JKb" userLabel="Send Card View" customClass="UICardView" customModule="Odysee" customModuleProvider="target">
-                                                <rect key="frame" x="16" y="840.5" width="382" height="163.5"/>
+                                                <rect key="frame" x="16" y="840.5" width="1048" height="163.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Send" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nkP-fk-HuS">
                                                         <rect key="frame" x="16" y="16" width="39" height="19.5"/>
@@ -753,7 +753,7 @@
                                                         <color key="color" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                                     </activityIndicatorView>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Recipient address" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="070-Pq-xY6">
-                                                        <rect key="frame" x="16" y="55.5" width="350" height="34"/>
+                                                        <rect key="frame" x="16" y="55.5" width="1016" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="continue"/>
                                                         <connections>
@@ -761,7 +761,7 @@
                                                         </connections>
                                                     </textField>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZP5-LD-373" userLabel="Lower View">
-                                                        <rect key="frame" x="16" y="101.5" width="350" height="46"/>
+                                                        <rect key="frame" x="16" y="101.5" width="1016" height="46"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="credits_icon" translatesAutoresizingMaskIntoConstraints="NO" id="blu-Dk-D7e">
                                                                 <rect key="frame" x="0.0" y="15" width="16" height="16"/>
@@ -782,7 +782,7 @@
                                                                 </connections>
                                                             </textField>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jc2-gI-wQ2" userLabel="Send Button">
-                                                                <rect key="frame" x="316" y="8.5" width="34" height="29"/>
+                                                                <rect key="frame" x="982" y="8.5" width="34" height="29"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <state key="normal" title="Send">
                                                                     <color key="titleColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
@@ -820,7 +820,7 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mjT-QX-WgY" userLabel="Recent Transactions Card View" customClass="UICardView" customModule="Odysee" customModuleProvider="target">
-                                                <rect key="frame" x="16" y="1020" width="382" height="671.5"/>
+                                                <rect key="frame" x="16" y="1020" width="1048" height="671.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Recent Transactions" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S3I-60-YFb">
                                                         <rect key="frame" x="16" y="16" width="154.5" height="595.5"/>
@@ -829,7 +829,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UBZ-2V-tnK">
-                                                        <rect key="frame" x="315" y="12" width="51" height="29"/>
+                                                        <rect key="frame" x="981" y="12" width="51" height="29"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <state key="normal" title="View All">
                                                             <color key="titleColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
@@ -839,7 +839,7 @@
                                                         </connections>
                                                     </button>
                                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="MbK-i8-7G5">
-                                                        <rect key="frame" x="16" y="631.5" width="350" height="24"/>
+                                                        <rect key="frame" x="16" y="631.5" width="1016" height="24"/>
                                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="24" id="uIp-OM-Oy8"/>
@@ -847,10 +847,10 @@
                                                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                         <prototypes>
                                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="recent_tx_cell" id="dae-jJ-R5A" customClass="TransactionTableViewCell" customModule="Odysee" customModuleProvider="target">
-                                                                <rect key="frame" x="0.0" y="28" width="350" height="44"/>
+                                                                <rect key="frame" x="0.0" y="28" width="1016" height="44"/>
                                                                 <autoresizingMask key="autoresizingMask"/>
                                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="dae-jJ-R5A" id="xuA-he-fF1">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="350" height="44"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="746" height="44"/>
                                                                     <autoresizingMask key="autoresizingMask"/>
                                                                     <subviews>
                                                                         <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="txR-bt-pfy">
@@ -937,7 +937,7 @@
                                                         </connections>
                                                     </tableView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="There are no transactions to display at this time." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="v9z-0B-3kh">
-                                                        <rect key="frame" x="16" y="631.5" width="350" height="24"/>
+                                                        <rect key="frame" x="16" y="631.5" width="1016" height="24"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -1034,11 +1034,11 @@
             <objects>
                 <viewController id="vf1-cE-yLr" customClass="LibraryViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="fTS-u3-hj4">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="800"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="758"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="o77-y4-e50">
-                                <rect key="frame" x="0.0" y="44" width="414" height="707"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="708"/>
                             </containerView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="O4a-O3-pFP"/>
@@ -1064,23 +1064,23 @@
             <objects>
                 <viewController id="fdD-dx-ZmO" customClass="FollowingViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Scz-9v-AbQ">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="800"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="758"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EcR-1L-mWs">
-                                <rect key="frame" x="0.0" y="44" width="414" height="707"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="708"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="SMc-0k-i3m">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="61.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="1080" height="61.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Channels you follow" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="973-hM-WdY">
-                                                <rect key="frame" x="16" y="0.0" width="382" height="21.5"/>
+                                                <rect key="frame" x="16" y="0.0" width="1048" height="21.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qhe-el-9RC" userLabel="Sort Options View">
-                                                <rect key="frame" x="16" y="29.5" width="382" height="24"/>
+                                                <rect key="frame" x="16" y="29.5" width="1048" height="24"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="5pW-H5-siz">
                                                         <rect key="frame" x="0.0" y="0.0" width="39.5" height="24"/>
@@ -1108,7 +1108,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Discover" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WV3-rg-wzc">
-                                                        <rect key="frame" x="325.5" y="0.0" width="56.5" height="24"/>
+                                                        <rect key="frame" x="991.5" y="0.0" width="56.5" height="24"/>
                                                         <gestureRecognizers/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="24" id="nZR-QM-JTd"/>
@@ -1137,7 +1137,7 @@
                                         <edgeInsets key="layoutMargins" top="0.0" left="16" bottom="8" right="16"/>
                                     </stackView>
                                     <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="QLu-vX-V38">
-                                        <rect key="frame" x="0.0" y="61.5" width="414" height="120"/>
+                                        <rect key="frame" x="0.0" y="61.5" width="1080" height="120"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="120" id="WTb-2a-sSM"/>
@@ -1191,7 +1191,7 @@
                                         </connections>
                                     </collectionView>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="isd-PF-mar">
-                                        <rect key="frame" x="0.0" y="181.5" width="414" height="525.5"/>
+                                        <rect key="frame" x="0.0" y="181.5" width="1080" height="526.5"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <connections>
                                             <outlet property="dataSource" destination="fdD-dx-ZmO" id="N2d-aj-SuV"/>
@@ -1205,16 +1205,16 @@
                                 </constraints>
                             </stackView>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1yL-UK-7uX">
-                                <rect key="frame" x="0.0" y="44" width="414" height="707"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="708"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Odysee works better if you follow a couple of creators you like." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YnH-Vh-hfX">
-                                        <rect key="frame" x="16" y="0.0" width="382" height="33.5"/>
+                                        <rect key="frame" x="16" y="0.0" width="1048" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="nK5-7p-2QP">
-                                        <rect key="frame" x="0.0" y="49.5" width="414" height="596.5"/>
+                                        <rect key="frame" x="0.0" y="33" width="1080" height="614"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="vpa-M5-ecr">
                                             <size key="itemSize" width="100" height="100"/>
@@ -1290,7 +1290,7 @@
                                         </connections>
                                     </collectionView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7uQ-Jx-ysn">
-                                        <rect key="frame" x="16" y="662" width="382" height="29"/>
+                                        <rect key="frame" x="16" y="663" width="1048" height="29"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <state key="normal" title="Done"/>
                                         <connections>
@@ -1313,7 +1313,7 @@
                                 </constraints>
                             </view>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IFd-jt-YE1">
-                                <rect key="frame" x="175" y="368" width="64" height="64"/>
+                                <rect key="frame" x="508" y="347" width="64" height="64"/>
                                 <subviews>
                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="bHk-ny-0TW">
                                         <rect key="frame" x="13.5" y="13.5" width="37" height="37"/>
@@ -1383,23 +1383,23 @@
             <objects>
                 <viewController storyboardIdentifier="notifications_vc" id="n4Y-p7-mVm" customClass="NotificationsViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="vs4-vd-umE">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="CT0-up-rRK">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="notification_cell" id="CBC-yc-Lg6" customClass="NotificationTableViewCell" customModule="Odysee" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="414" height="136.5"/>
+                                        <rect key="frame" x="0.0" y="28" width="1080" height="138"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="CBC-yc-Lg6" id="CyX-RZ-AKz">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="136.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="1080" height="138"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nec-jl-R4W">
-                                                    <rect key="frame" x="16" y="48.5" width="40" height="40"/>
+                                                    <rect key="frame" x="16" y="49" width="40" height="40"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="r5b-JC-PNb">
                                                             <rect key="frame" x="0.0" y="0.0" width="40" height="40"/>
@@ -1427,22 +1427,22 @@
                                                     </constraints>
                                                 </view>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="Rkn-qw-1Ja">
-                                                    <rect key="frame" x="72" y="12" width="298" height="112.5"/>
+                                                    <rect key="frame" x="72" y="12" width="964" height="114"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E1P-Ch-8kS">
-                                                            <rect key="frame" x="0.0" y="0.0" width="298" height="0.0"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="964" height="0.0"/>
                                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Mc-q5-pLo">
-                                                            <rect key="frame" x="0.0" y="3" width="298" height="0.0"/>
+                                                            <rect key="frame" x="0.0" y="3" width="964" height="0.0"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KCt-HX-Xa4">
-                                                            <rect key="frame" x="0.0" y="6" width="298" height="106.5"/>
+                                                            <rect key="frame" x="0.0" y="6" width="964" height="108"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -1450,7 +1450,7 @@
                                                     </subviews>
                                                 </stackView>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1ka-fK-072">
-                                                    <rect key="frame" x="386" y="62.5" width="12" height="12"/>
+                                                    <rect key="frame" x="1052" y="63" width="12" height="12"/>
                                                     <color key="backgroundColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="12" id="UBc-HJ-Ahx"/>
@@ -1485,7 +1485,7 @@
                                 </connections>
                             </tableView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="wAf-fp-Flu">
-                                <rect key="frame" x="107" y="311" width="200" height="274.5"/>
+                                <rect key="frame" x="440" y="268" width="200" height="274.5"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="spaceman_happy" translatesAutoresizingMaskIntoConstraints="NO" id="zMZ-ec-Thl">
                                         <rect key="frame" x="0.0" y="0.0" width="200" height="200"/>
@@ -1507,7 +1507,7 @@
                                 </constraints>
                             </stackView>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gNZ-yR-hgC">
-                                <rect key="frame" x="175" y="416" width="64" height="64"/>
+                                <rect key="frame" x="508" y="373" width="64" height="64"/>
                                 <subviews>
                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="6QA-jB-Wk5">
                                         <rect key="frame" x="13.5" y="13.5" width="37" height="37"/>
@@ -1552,11 +1552,11 @@
             <objects>
                 <viewController storyboardIdentifier="home_vc" title="Home" id="BYZ-38-t0r" customClass="HomeViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="800"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="758"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" bounces="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9jV-NE-VWg">
-                                <rect key="frame" x="87" y="44" width="240" height="40"/>
+                                <rect key="frame" x="87" y="0.0" width="240" height="40"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" distribution="equalSpacing" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="w63-FZ-Oi2">
                                         <rect key="frame" x="-46" y="0.0" width="200" height="40"/>
@@ -1573,7 +1573,7 @@
                                 </constraints>
                             </scrollView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="azd-7J-GfZ" userLabel="Sort Options View">
-                                <rect key="frame" x="0.0" y="88" width="414" height="24"/>
+                                <rect key="frame" x="0.0" y="44" width="1080" height="24"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="lbt-6r-Umu">
                                         <rect key="frame" x="18" y="0.0" width="67" height="24"/>
@@ -1612,7 +1612,7 @@
                                 </constraints>
                             </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="E1b-cq-Meq">
-                                <rect key="frame" x="0.0" y="116" width="414" height="635"/>
+                                <rect key="frame" x="0.0" y="72" width="1080" height="636"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <connections>
                                     <outlet property="dataSource" destination="BYZ-38-t0r" id="wfX-kn-0Vy"/>
@@ -1621,7 +1621,7 @@
                                 </connections>
                             </tableView>
                             <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="CEB-nI-u0n">
-                                <rect key="frame" x="87" y="251.5" width="240" height="297.5"/>
+                                <rect key="frame" x="420" y="230.5" width="240" height="297.5"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="spaceman_sad" translatesAutoresizingMaskIntoConstraints="NO" id="Yf7-8q-F5G">
                                         <rect key="frame" x="0.0" y="0.0" width="240" height="240"/>
@@ -1643,7 +1643,7 @@
                                 </constraints>
                             </stackView>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TRZ-ZH-YFM">
-                                <rect key="frame" x="175" y="368" width="64" height="64"/>
+                                <rect key="frame" x="508" y="347" width="64" height="64"/>
                                 <subviews>
                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="fYk-nV-as0">
                                         <rect key="frame" x="13.5" y="13.5" width="37" height="37"/>
@@ -1708,46 +1708,46 @@
             <objects>
                 <viewController storyboardIdentifier="ua_vc" id="yQM-IV-uQ4" customClass="UserAccountViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="S9W-F5-ofR">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ua_background" translatesAutoresizingMaskIntoConstraints="NO" id="auK-mi-YlJ">
-                                <rect key="frame" x="0.0" y="44" width="414" height="852"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                             </imageView>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zQM-9E-uTu">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oxc-eR-0ui" userLabel="Content View">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="818"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="spaceman_white" translatesAutoresizingMaskIntoConstraints="NO" id="VT2-oZ-lbb">
-                                                <rect key="frame" x="127" y="72" width="160" height="160"/>
+                                                <rect key="frame" x="460" y="72" width="160" height="160"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="160" id="OBg-tE-kBe"/>
                                                     <constraint firstAttribute="width" constant="160" id="PeE-0b-E8B"/>
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Join Odysee" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i9h-Zm-yIh">
-                                                <rect key="frame" x="160" y="264" width="94.5" height="20.5"/>
+                                                <rect key="frame" x="493" y="264" width="94.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Y9g-sJ-Zz8">
-                                                <rect key="frame" x="64" y="316.5" width="286" height="189"/>
+                                                <rect key="frame" x="64" y="316.5" width="952" height="174.5"/>
                                                 <subviews>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Email" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="v78-DT-l4h">
-                                                        <rect key="frame" x="0.0" y="0.0" width="286" height="34"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="952" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="emailAddress" textContentType="email"/>
                                                     </textField>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Nt2-WM-4WI">
-                                                        <rect key="frame" x="0.0" y="54" width="286" height="34"/>
+                                                        <rect key="frame" x="0.0" y="54" width="952" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" secureTextEntry="YES" textContentType="new-password"/>
                                                     </textField>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="P6e-4R-4iL" customClass="UAButton" customModule="Odysee" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="108" width="286" height="32"/>
+                                                        <rect key="frame" x="0.0" y="108" width="952" height="32"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="32" id="7y4-pm-UKx"/>
                                                         </constraints>
@@ -1760,7 +1760,7 @@
                                                         </connections>
                                                     </button>
                                                     <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mtA-8f-99U">
-                                                        <rect key="frame" x="0.0" y="150" width="286" height="0.0"/>
+                                                        <rect key="frame" x="0.0" y="150" width="952" height="0.0"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                         <state key="normal" title="Use magic link"/>
                                                         <connections>
@@ -1768,7 +1768,7 @@
                                                         </connections>
                                                     </button>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="By creating an account, you agree to our terms and confirm that you are over the age of 13." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Uf-8u-BrQ">
-                                                        <rect key="frame" x="0.0" y="160" width="286" height="29"/>
+                                                        <rect key="frame" x="0.0" y="160" width="952" height="14.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -1776,7 +1776,7 @@
                                                 </subviews>
                                             </stackView>
                                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6F4-mD-ink">
-                                                <rect key="frame" x="64" y="399.5" width="286" height="60"/>
+                                                <rect key="frame" x="64" y="349.5" width="952" height="60"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wMt-rk-s1Q">
                                                         <rect key="frame" x="0.0" y="15.5" width="87" height="29"/>
@@ -1789,7 +1789,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LKj-fl-rrW" userLabel="Start Over">
-                                                        <rect key="frame" x="219" y="15.5" width="67" height="29"/>
+                                                        <rect key="frame" x="885" y="15.5" width="67" height="29"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <state key="normal" title="Start Over">
                                                             <color key="titleColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
@@ -1808,14 +1808,14 @@
                                                 </constraints>
                                             </view>
                                             <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SWA-vL-8mE">
-                                                <rect key="frame" x="64" y="316.5" width="286" height="67"/>
+                                                <rect key="frame" x="64" y="316.5" width="952" height="17"/>
                                                 <string key="text">We sent an email to the address you provided. Please click the link in the message to complete email verification and continue using Odysee.</string>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5G2-rP-yk6" userLabel="Switch Mode Button" customClass="UAButton" customModule="Odysee" customModuleProvider="target">
-                                                <rect key="frame" x="135.5" y="770" width="143" height="32"/>
+                                                <rect key="frame" x="302" y="762" width="476" height="32"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="32" id="hca-RP-Wnv"/>
                                                 </constraints>
@@ -1834,7 +1834,7 @@
                                                 </connections>
                                             </button>
                                             <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Already have an account?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tKf-c4-XRO">
-                                                <rect key="frame" x="64" y="734" width="286" height="16"/>
+                                                <rect key="frame" x="64" y="726" width="952" height="16"/>
                                                 <gestureRecognizers/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -1883,7 +1883,7 @@
                                 </constraints>
                             </scrollView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="close" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6Rh-Q5-YIW">
-                                <rect key="frame" x="368" y="60" width="30" height="30"/>
+                                <rect key="frame" x="1034" y="16" width="30" height="30"/>
                                 <connections>
                                     <action selector="closeButtonTapped:" destination="yQM-IV-uQ4" eventType="touchUpInside" id="EwW-XK-Lc8"/>
                                 </connections>
@@ -1940,24 +1940,24 @@
             <objects>
                 <viewController storyboardIdentifier="wallet_sync_vc" id="4QY-KF-YHE" customClass="WalletSyncViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="kjS-xh-WYx">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="odysee_logo" translatesAutoresizingMaskIntoConstraints="NO" id="e1N-L1-VPt">
-                                <rect key="frame" x="127" y="172" width="160" height="160"/>
+                                <rect key="frame" x="460" y="128" width="160" height="160"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="160" id="0CX-k2-kUq"/>
                                     <constraint firstAttribute="height" constant="160" id="TMN-w9-iZI"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Retrieving account details..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DqD-QE-zQz">
-                                <rect key="frame" x="117" y="396" width="180" height="17"/>
+                                <rect key="frame" x="450" y="352" width="180" height="17"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="Zxg-rD-u6o">
-                                <rect key="frame" x="188.5" y="445" width="37" height="37"/>
+                                <rect key="frame" x="521.5" y="401" width="37" height="37"/>
                                 <color key="color" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                             </activityIndicatorView>
                         </subviews>
@@ -1982,61 +1982,61 @@
             <objects>
                 <viewController storyboardIdentifier="yt_sync_vc" id="h1g-cI-MnY" customClass="YouTubeSyncViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Q96-4f-F2j">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5mM-Lb-JXr">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zuj-jc-p10">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="519"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="1080" height="440.5"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="odysee_logo" translatesAutoresizingMaskIntoConstraints="NO" id="RY4-UQ-a9b">
-                                                <rect key="frame" x="167" y="32" width="80" height="80"/>
+                                                <rect key="frame" x="500" y="32" width="80" height="80"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="80" id="2Ux-dC-BCe"/>
                                                     <constraint firstAttribute="height" constant="80" id="Nzq-wV-gVq"/>
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sync your YouTube channel to Odysee" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Qu-O7-IOS">
-                                                <rect key="frame" x="16" y="144" width="382" height="20.5"/>
+                                                <rect key="frame" x="16" y="144" width="1048" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Get your YouTube videos in front of the Odysee audience" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d97-BL-G0e">
-                                                <rect key="frame" x="16" y="168.5" width="382" height="17"/>
+                                                <rect key="frame" x="16" y="168.5" width="1048" height="17"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tt4-4I-IKF">
-                                                <rect key="frame" x="16" y="209.5" width="382" height="59"/>
+                                                <rect key="frame" x="16" y="209.5" width="1048" height="59"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your Odysee channel name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9cI-20-TY3">
-                                                        <rect key="frame" x="0.0" y="0.0" width="382" height="17"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="1048" height="17"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="channel" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jGG-4e-mRH">
-                                                        <rect key="frame" x="0.0" y="25" width="382" height="34"/>
+                                                        <rect key="frame" x="0.0" y="25" width="1048" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits"/>
                                                     </textField>
                                                 </subviews>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4yu-EV-30m" userLabel="Confirmation View">
-                                                <rect key="frame" x="16" y="284.5" width="382" height="83"/>
+                                                <rect key="frame" x="16" y="284.5" width="1048" height="33"/>
                                                 <subviews>
                                                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="ee9-fl-Fqn">
-                                                        <rect key="frame" x="0.0" y="26" width="51" height="31"/>
+                                                        <rect key="frame" x="0.0" y="1" width="51" height="31"/>
                                                         <connections>
                                                             <action selector="switchValueChanged:" destination="h1g-cI-MnY" eventType="valueChanged" id="W4q-Qd-g8k"/>
                                                         </connections>
                                                     </switch>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jcS-s2-XF0">
-                                                        <rect key="frame" x="65" y="8" width="317" height="67"/>
+                                                        <rect key="frame" x="65" y="8" width="983" height="17"/>
                                                         <string key="text">I want to sync my content to Odysee and the LBRY network and agree to these terms. I have also read and understand how the program works.</string>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <nil key="textColor"/>
@@ -2054,7 +2054,7 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BTn-If-qF6" userLabel="Action Buttons">
-                                                <rect key="frame" x="16" y="383.5" width="382" height="46"/>
+                                                <rect key="frame" x="16" y="333.5" width="1048" height="46"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bAb-1g-rap">
                                                         <rect key="frame" x="0.0" y="8" width="73" height="30"/>
@@ -2066,14 +2066,14 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xWL-Hl-Y6A">
-                                                        <rect key="frame" x="352" y="8" width="30" height="30"/>
+                                                        <rect key="frame" x="1018" y="8" width="30" height="30"/>
                                                         <state key="normal" title="Skip"/>
                                                         <connections>
                                                             <action selector="skipPressed:" destination="h1g-cI-MnY" eventType="touchUpInside" id="bTy-Ed-wpx"/>
                                                         </connections>
                                                     </button>
                                                     <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="El2-gM-Vmg">
-                                                        <rect key="frame" x="181" y="13" width="20" height="20"/>
+                                                        <rect key="frame" x="514" y="13" width="20" height="20"/>
                                                         <color key="color" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                                     </activityIndicatorView>
                                                 </subviews>
@@ -2090,7 +2090,7 @@
                                                 </constraints>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bMq-2y-YNx">
-                                                <rect key="frame" x="16" y="445.5" width="382" height="57.5"/>
+                                                <rect key="frame" x="16" y="395.5" width="1048" height="29"/>
                                                 <string key="text">This will verify you are an active YouTuber. Channel names cannot be changed once chosen, please be extra careful. Additional instructions will be emailed to you after you verify your email on the next page. Learn more.</string>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <nil key="textColor"/>
@@ -2132,7 +2132,7 @@
                                 </constraints>
                             </scrollView>
                             <wkWebView hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YMA-2F-FBO">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                                 <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <wkWebViewConfiguration key="configuration">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
@@ -2172,42 +2172,42 @@
             <objects>
                 <viewController storyboardIdentifier="yt_sync_status_vc" id="GBa-fn-Xgi" customClass="YouTubeSyncStatusViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="umg-df-ztx">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DmL-sP-xiI">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="S3W-7r-2w7">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="426"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="1080" height="426"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="odysee_logo" translatesAutoresizingMaskIntoConstraints="NO" id="dQz-0D-Rij">
-                                                <rect key="frame" x="167" y="32" width="80" height="80"/>
+                                                <rect key="frame" x="500" y="32" width="80" height="80"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="80" id="Fls-BY-Xwh"/>
                                                     <constraint firstAttribute="height" constant="80" id="VG5-wc-cY7"/>
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your YouTube Channel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1G5-NT-zUU">
-                                                <rect key="frame" x="16" y="144" width="382" height="20.5"/>
+                                                <rect key="frame" x="16" y="144" width="1048" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Please check back later. This may take up to 1 week." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CO8-vi-Vkw">
-                                                <rect key="frame" x="16" y="168.5" width="382" height="17"/>
+                                                <rect key="frame" x="16" y="168.5" width="1048" height="17"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="e5Z-EF-bGu">
-                                                <rect key="frame" x="16" y="209.5" width="382" height="108"/>
+                                                <rect key="frame" x="16" y="209.5" width="1048" height="108"/>
                                                 <subviews>
                                                     <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="N7H-RV-p3s">
-                                                        <rect key="frame" x="0.0" y="0.0" width="382" height="68"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="1048" height="68"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="j6o-iC-L47">
-                                                                <rect key="frame" x="0.0" y="0.0" width="382" height="16"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="1048" height="16"/>
                                                                 <subviews>
                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="circle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="vsB-GF-Oye">
                                                                         <rect key="frame" x="16" y="10.5" width="16" height="15"/>
@@ -2218,7 +2218,7 @@
                                                                         </constraints>
                                                                     </imageView>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Claim your handle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TU1-d3-TWe">
-                                                                        <rect key="frame" x="40" y="8" width="326" height="0.0"/>
+                                                                        <rect key="frame" x="40" y="8" width="992" height="0.0"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
@@ -2235,7 +2235,7 @@
                                                                 </constraints>
                                                             </view>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qlW-Vl-gis">
-                                                                <rect key="frame" x="0.0" y="16" width="382" height="16"/>
+                                                                <rect key="frame" x="0.0" y="16" width="1048" height="16"/>
                                                                 <subviews>
                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="circle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Jzb-0s-YBz">
                                                                         <rect key="frame" x="16" y="10.5" width="16" height="15"/>
@@ -2246,7 +2246,7 @@
                                                                         </constraints>
                                                                     </imageView>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Agree to sync" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lNg-y1-QOn">
-                                                                        <rect key="frame" x="40" y="8" width="326" height="0.0"/>
+                                                                        <rect key="frame" x="40" y="8" width="992" height="0.0"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
@@ -2263,7 +2263,7 @@
                                                                 </constraints>
                                                             </view>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yxT-J8-oyq">
-                                                                <rect key="frame" x="0.0" y="32" width="382" height="20"/>
+                                                                <rect key="frame" x="0.0" y="32" width="1048" height="20"/>
                                                                 <subviews>
                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="circle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="1Ri-G3-H0U">
                                                                         <rect key="frame" x="16" y="10.5" width="16" height="15"/>
@@ -2274,13 +2274,13 @@
                                                                         </constraints>
                                                                     </imageView>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Wait for your videos to be synced" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oJM-ys-rd0">
-                                                                        <rect key="frame" x="40" y="8" width="326" height="0.0"/>
+                                                                        <rect key="frame" x="40" y="8" width="992" height="0.0"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y3D-p1-oEb">
-                                                                        <rect key="frame" x="40" y="12" width="326" height="0.0"/>
+                                                                        <rect key="frame" x="40" y="12" width="992" height="0.0"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
@@ -2301,7 +2301,7 @@
                                                                 </constraints>
                                                             </view>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zoC-pq-lHC">
-                                                                <rect key="frame" x="0.0" y="52" width="382" height="16"/>
+                                                                <rect key="frame" x="0.0" y="52" width="1048" height="16"/>
                                                                 <subviews>
                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="circle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="jTE-wM-cTO">
                                                                         <rect key="frame" x="16" y="10.5" width="16" height="15"/>
@@ -2312,7 +2312,7 @@
                                                                         </constraints>
                                                                     </imageView>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Claim your channel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QIi-B5-OxL">
-                                                                        <rect key="frame" x="40" y="8" width="326" height="0.0"/>
+                                                                        <rect key="frame" x="40" y="8" width="992" height="0.0"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
@@ -2331,16 +2331,16 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Abd-Lm-Efj">
-                                                        <rect key="frame" x="0.0" y="0.0" width="382" height="108"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="1048" height="108"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZT9-VX-uPQ">
-                                                                <rect key="frame" x="0.0" y="0.0" width="382" height="50"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="1048" height="50"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u6m-wR-xb9">
-                                                                <rect key="frame" x="0.0" y="58" width="382" height="50"/>
+                                                                <rect key="frame" x="0.0" y="58" width="1048" height="50"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -2350,7 +2350,7 @@
                                                 </subviews>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XSo-D3-IKF" userLabel="Action Buttons">
-                                                <rect key="frame" x="16" y="333.5" width="382" height="46"/>
+                                                <rect key="frame" x="16" y="333.5" width="1048" height="46"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Z7Z-hl-tYY">
                                                         <rect key="frame" x="0.0" y="8" width="99" height="30"/>
@@ -2363,7 +2363,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Aae-5l-HCw">
-                                                        <rect key="frame" x="274" y="8" width="108" height="30"/>
+                                                        <rect key="frame" x="940" y="8" width="108" height="30"/>
                                                         <state key="normal" title="Explore Odysee"/>
                                                         <connections>
                                                             <action selector="exploreOdyseeTapped:" destination="GBa-fn-Xgi" eventType="touchUpInside" id="ewY-vM-b34"/>
@@ -2371,7 +2371,7 @@
                                                         </connections>
                                                     </button>
                                                     <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="4op-Im-OsO">
-                                                        <rect key="frame" x="181" y="13" width="20" height="20"/>
+                                                        <rect key="frame" x="514" y="13" width="20" height="20"/>
                                                         <color key="color" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                                     </activityIndicatorView>
                                                 </subviews>
@@ -2388,7 +2388,7 @@
                                                 </constraints>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="You will be able to claim your channel once it has finished syncing." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pJb-If-2ha">
-                                                <rect key="frame" x="16" y="395.5" width="382" height="14.5"/>
+                                                <rect key="frame" x="16" y="395.5" width="1048" height="14.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -2461,11 +2461,11 @@
             <objects>
                 <viewController storyboardIdentifier="transactions_vc" id="qoF-EZ-GzH" customClass="TransactionsViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="j0P-YB-uuh">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="EUK-IN-E0U">
-                                <rect key="frame" x="107" y="319.5" width="200" height="257.5"/>
+                                <rect key="frame" x="440" y="276.5" width="200" height="257.5"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="spaceman_sad" translatesAutoresizingMaskIntoConstraints="NO" id="BMv-Hk-xgT">
                                         <rect key="frame" x="0.0" y="0.0" width="200" height="200"/>
@@ -2487,25 +2487,25 @@
                                 </constraints>
                             </stackView>
                             <tableView hidden="YES" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="rod-Kr-PUF">
-                                <rect key="frame" x="0.0" y="92" width="414" height="770"/>
+                                <rect key="frame" x="0.0" y="48" width="1080" height="762"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="tx_cell" id="41A-mi-l0F" customClass="TransactionTableViewCell" customModule="Odysee" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="414" height="104"/>
+                                        <rect key="frame" x="0.0" y="28" width="1080" height="104"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="41A-mi-l0F" id="ZPt-6H-LGt">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="104"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="1080" height="104"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cE0-vJ-l59">
-                                                    <rect key="frame" x="0.0" y="0.0" width="414" height="104"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="1080" height="104"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Xrm-wA-4GB" userLabel="Left Side">
-                                                            <rect key="frame" x="0.0" y="0.0" width="290" height="104"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="756" height="104"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="F2v-Gm-bLS">
-                                                                    <rect key="frame" x="24" y="8" width="366" height="16"/>
+                                                                    <rect key="frame" x="24" y="8" width="1032" height="16"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -2526,22 +2526,22 @@
                                                             <edgeInsets key="layoutMargins" top="8" left="24" bottom="8" right="8"/>
                                                         </stackView>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Rh4-3l-kVy" userLabel="Right Side">
-                                                            <rect key="frame" x="290" y="0.0" width="124" height="104"/>
+                                                            <rect key="frame" x="756" y="0.0" width="324" height="104"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7zd-Gm-rqM">
-                                                                    <rect key="frame" x="8" y="8" width="92" height="16"/>
+                                                                    <rect key="frame" x="8" y="8" width="292" height="16"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d5F-6F-Xyc">
-                                                                    <rect key="frame" x="8" y="28" width="92" height="50"/>
+                                                                    <rect key="frame" x="8" y="28" width="292" height="50"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IEA-bt-lb1">
-                                                                    <rect key="frame" x="8" y="82" width="92" height="14"/>
+                                                                    <rect key="frame" x="8" y="82" width="292" height="14"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -2582,7 +2582,7 @@
                                 </connections>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="86W-WE-3ML" userLabel="Page Title Area">
-                                <rect key="frame" x="0.0" y="44" width="414" height="48"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="48"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xrl-Mk-bwc">
                                         <rect key="frame" x="0.0" y="0.0" width="48" height="48"/>
@@ -2625,7 +2625,7 @@
                                 </constraints>
                             </view>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WDM-ej-laP">
-                                <rect key="frame" x="175" y="416" width="64" height="64"/>
+                                <rect key="frame" x="508" y="373" width="64" height="64"/>
                                 <subviews>
                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="vc8-JZ-MLi">
                                         <rect key="frame" x="13.5" y="13.5" width="37" height="37"/>
@@ -2678,11 +2678,11 @@
             <objects>
                 <viewController storyboardIdentifier="publishes_vc" id="S8q-7E-CQq" customClass="PublishesViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Mb7-Zl-als">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="kua-MI-1Rj">
-                                <rect key="frame" x="0.0" y="92" width="414" height="770"/>
+                                <rect key="frame" x="0.0" y="48" width="1080" height="762"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <connections>
                                     <outlet property="dataSource" destination="S8q-7E-CQq" id="HwA-wo-qCR"/>
@@ -2690,7 +2690,7 @@
                                 </connections>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GQL-Lh-auD" userLabel="Page Title Area">
-                                <rect key="frame" x="0.0" y="44" width="414" height="48"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="48"/>
                                 <subviews>
                                     <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nmk-8J-HRs">
                                         <rect key="frame" x="0.0" y="0.0" width="48" height="48"/>
@@ -2730,7 +2730,7 @@
                                 </constraints>
                             </view>
                             <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="fuq-Gc-HUF">
-                                <rect key="frame" x="107" y="300.5" width="200" height="295"/>
+                                <rect key="frame" x="440" y="257.5" width="200" height="295"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="spaceman_happy" translatesAutoresizingMaskIntoConstraints="NO" id="LMf-Vn-sHB">
                                         <rect key="frame" x="0.0" y="0.0" width="200" height="200"/>
@@ -2762,7 +2762,7 @@
                                 </constraints>
                             </stackView>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="h4U-Ns-b5g">
-                                <rect key="frame" x="175" y="416" width="64" height="64"/>
+                                <rect key="frame" x="508" y="373" width="64" height="64"/>
                                 <subviews>
                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="kQC-CX-3ht">
                                         <rect key="frame" x="13.5" y="13.5" width="37" height="37"/>
@@ -2809,11 +2809,11 @@
             <objects>
                 <viewController storyboardIdentifier="publish_vc" id="Msd-wJ-nEU" customClass="PublishViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="z5U-z9-aaa">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VCt-ej-sPj" userLabel="Page Title Area">
-                                <rect key="frame" x="0.0" y="44" width="414" height="48"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="48"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9fX-7i-o1C">
                                         <rect key="frame" x="0.0" y="0.0" width="48" height="48"/>
@@ -2856,25 +2856,25 @@
                                 </constraints>
                             </view>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3wx-yg-s99">
-                                <rect key="frame" x="0.0" y="92" width="414" height="770"/>
+                                <rect key="frame" x="0.0" y="48" width="1080" height="762"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="xEP-Ej-crw">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="1285"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="1080" height="1256"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="5c6-Wh-5CE" userLabel="Main">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="361"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="1080" height="346.5"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="jyd-sK-L67">
-                                                        <rect key="frame" x="16" y="0.0" width="382" height="87"/>
+                                                        <rect key="frame" x="16" y="0.0" width="1048" height="72.5"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VfZ-NE-vvl" userLabel="Name">
-                                                                <rect key="frame" x="0.0" y="0.0" width="382" height="16"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="1048" height="16"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="DRd-CF-0Ue">
-                                                                <rect key="frame" x="0.0" y="20" width="382" height="34"/>
+                                                                <rect key="frame" x="0.0" y="20" width="1048" height="34"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="odysee.com/" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xUS-Xi-t5E">
                                                                         <rect key="frame" x="0.0" y="0.0" width="82.5" height="34"/>
@@ -2883,7 +2883,7 @@
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Rxg-Cs-CLK">
-                                                                        <rect key="frame" x="84.5" y="0.0" width="297.5" height="34"/>
+                                                                        <rect key="frame" x="84.5" y="0.0" width="963.5" height="34"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                         <textInputTraits key="textInputTraits"/>
                                                                         <connections>
@@ -2894,7 +2894,7 @@
                                                                 </subviews>
                                                             </stackView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Create a URL for this content. Simpler names are easier to find and remember." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="55S-6q-Igt">
-                                                                <rect key="frame" x="0.0" y="58" width="382" height="29"/>
+                                                                <rect key="frame" x="0.0" y="58" width="1048" height="14.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -2903,16 +2903,16 @@
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="yO2-u7-Xxc">
-                                                        <rect key="frame" x="16" y="103" width="382" height="54"/>
+                                                        <rect key="frame" x="16" y="88.5" width="1048" height="54"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KTJ-H0-QW2">
-                                                                <rect key="frame" x="0.0" y="0.0" width="382" height="16"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="1048" height="16"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Descriptive titles work best" textAlignment="natural" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Nyx-vN-Bmz">
-                                                                <rect key="frame" x="0.0" y="20" width="382" height="34"/>
+                                                                <rect key="frame" x="0.0" y="20" width="1048" height="34"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                                 <connections>
@@ -2923,16 +2923,16 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="imL-yl-lgr">
-                                                        <rect key="frame" x="16" y="173" width="382" height="84"/>
+                                                        <rect key="frame" x="16" y="158.5" width="1048" height="84"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Description" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1lA-1r-8to">
-                                                                <rect key="frame" x="0.0" y="0.0" width="382" height="16"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="1048" height="16"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="iQJ-66-ZUi">
-                                                                <rect key="frame" x="0.0" y="20" width="382" height="64"/>
+                                                                <rect key="frame" x="0.0" y="20" width="1048" height="64"/>
                                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="64" id="WyI-8H-QZx"/>
@@ -2944,16 +2944,16 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Yrc-eH-HDp">
-                                                        <rect key="frame" x="16" y="273" width="382" height="88"/>
+                                                        <rect key="frame" x="16" y="258.5" width="1048" height="88"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Video file" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zWF-zZ-aX5">
-                                                                <rect key="frame" x="0.0" y="0.0" width="382" height="16"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="1048" height="16"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="No video selected" textAlignment="natural" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5DK-68-frH">
-                                                                <rect key="frame" x="0.0" y="20" width="382" height="34"/>
+                                                                <rect key="frame" x="0.0" y="20" width="1048" height="34"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                                 <connections>
@@ -2962,7 +2962,7 @@
                                                                 </connections>
                                                             </textField>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1cH-Ge-6mX">
-                                                                <rect key="frame" x="0.0" y="58" width="382" height="30"/>
+                                                                <rect key="frame" x="0.0" y="58" width="1048" height="30"/>
                                                                 <state key="normal" title="Select a video">
                                                                     <color key="titleColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                                                 </state>
@@ -2977,23 +2977,23 @@
                                                 <edgeInsets key="layoutMargins" top="0.0" left="16" bottom="0.0" right="16"/>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XWc-ux-yqZ" userLabel="Divider">
-                                                <rect key="frame" x="0.0" y="377" width="414" height="1"/>
+                                                <rect key="frame" x="0.0" y="362.5" width="1080" height="1"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="cRn-64-Sfp"/>
                                                 </constraints>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="0Rh-F0-824" userLabel="Publish As Area">
-                                                <rect key="frame" x="0.0" y="394" width="414" height="124"/>
+                                                <rect key="frame" x="0.0" y="379.5" width="1080" height="124"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Publish as" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aZZ-eS-jXE">
-                                                        <rect key="frame" x="16" y="0.0" width="382" height="16"/>
+                                                        <rect key="frame" x="16" y="0.0" width="1048" height="16"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yhv-Co-fdU">
-                                                        <rect key="frame" x="16" y="24" width="382" height="100"/>
+                                                        <rect key="frame" x="16" y="24" width="1048" height="100"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="100" id="9nv-A8-yJt"/>
                                                         </constraints>
@@ -3006,23 +3006,23 @@
                                                 <edgeInsets key="layoutMargins" top="0.0" left="16" bottom="0.0" right="16"/>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E7p-dR-pC2" userLabel="Divider">
-                                                <rect key="frame" x="0.0" y="534" width="414" height="1"/>
+                                                <rect key="frame" x="0.0" y="519.5" width="1080" height="1"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="g7L-NG-Squ"/>
                                                 </constraints>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ZGK-Bh-N6t" userLabel="Thumbnail Area">
-                                                <rect key="frame" x="0.0" y="551" width="414" height="130"/>
+                                                <rect key="frame" x="0.0" y="536.5" width="1080" height="130"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Thumbnail" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="imW-NT-wO7" userLabel="Thumbnail">
-                                                        <rect key="frame" x="16" y="0.0" width="382" height="16"/>
+                                                        <rect key="frame" x="16" y="0.0" width="1048" height="16"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fa2-35-tgf">
-                                                        <rect key="frame" x="16" y="24" width="382" height="106"/>
+                                                        <rect key="frame" x="16" y="24" width="1048" height="106"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="spaceman" translatesAutoresizingMaskIntoConstraints="NO" id="7bS-GP-EdN">
                                                                 <rect key="frame" x="0.0" y="8" width="160" height="90"/>
@@ -3052,10 +3052,10 @@
                                                                 <edgeInsets key="layoutMargins" top="0.0" left="8" bottom="0.0" right="8"/>
                                                             </stackView>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="S8M-e5-bQB">
-                                                                <rect key="frame" x="176" y="8" width="206" height="64"/>
+                                                                <rect key="frame" x="176" y="8" width="872" height="64"/>
                                                                 <subviews>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pcZ-cv-fnd">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="206" height="28"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="872" height="28"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                         <state key="normal" title="Select an image">
                                                                             <color key="titleColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
@@ -3065,7 +3065,7 @@
                                                                         </connections>
                                                                     </button>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vec-ew-jqK">
-                                                                        <rect key="frame" x="0.0" y="36" width="206" height="28"/>
+                                                                        <rect key="frame" x="0.0" y="36" width="872" height="28"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                         <state key="normal" title="Generate thumbnail">
                                                                             <color key="titleColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
@@ -3093,23 +3093,23 @@
                                                 <edgeInsets key="layoutMargins" top="0.0" left="16" bottom="0.0" right="16"/>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yQa-u0-NmL" userLabel="Divider">
-                                                <rect key="frame" x="0.0" y="697" width="414" height="1"/>
+                                                <rect key="frame" x="0.0" y="682.5" width="1080" height="1"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="Dqn-yy-Ado"/>
                                                 </constraints>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="BGc-uJ-XSE" userLabel="Deposit Area">
-                                                <rect key="frame" x="0.0" y="714" width="414" height="189"/>
+                                                <rect key="frame" x="0.0" y="699.5" width="1080" height="174.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Deposit" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ww0-QA-XOG">
-                                                        <rect key="frame" x="16" y="0.0" width="382" height="16"/>
+                                                        <rect key="frame" x="16" y="0.0" width="1048" height="16"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kGK-eP-GxJ">
-                                                        <rect key="frame" x="16" y="24" width="382" height="128"/>
+                                                        <rect key="frame" x="16" y="24" width="1048" height="128"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="credits_icon" translatesAutoresizingMaskIntoConstraints="NO" id="DA0-uK-mxH">
                                                                 <rect key="frame" x="0.0" y="56" width="16" height="16"/>
@@ -3140,7 +3140,7 @@
                                                         </constraints>
                                                     </view>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Any amount will give you the highest bid, but larger amounts help your content be trusted and discovered." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rFE-zm-eP3">
-                                                        <rect key="frame" x="16" y="160" width="382" height="29"/>
+                                                        <rect key="frame" x="16" y="160" width="1048" height="14.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -3149,23 +3149,23 @@
                                                 <edgeInsets key="layoutMargins" top="0.0" left="16" bottom="0.0" right="16"/>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YSo-JT-v70" userLabel="Divider">
-                                                <rect key="frame" x="0.0" y="919" width="414" height="1"/>
+                                                <rect key="frame" x="0.0" y="890" width="1080" height="1"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="9dY-AZ-VhJ"/>
                                                 </constraints>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Y1V-qn-ofy" userLabel="Additional Options Area">
-                                                <rect key="frame" x="0.0" y="936" width="414" height="256"/>
+                                                <rect key="frame" x="0.0" y="907" width="1080" height="256"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Language" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eNA-sk-Os6">
-                                                        <rect key="frame" x="16" y="0.0" width="382" height="16"/>
+                                                        <rect key="frame" x="16" y="0.0" width="1048" height="16"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="add-Qu-OSY">
-                                                        <rect key="frame" x="16" y="24" width="382" height="100"/>
+                                                        <rect key="frame" x="16" y="24" width="1048" height="100"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="100" id="yhw-6S-Kil"/>
                                                         </constraints>
@@ -3175,13 +3175,13 @@
                                                         </connections>
                                                     </pickerView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="License" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Ak-f8-524">
-                                                        <rect key="frame" x="16" y="132" width="382" height="16"/>
+                                                        <rect key="frame" x="16" y="132" width="1048" height="16"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="o4E-8G-MgU">
-                                                        <rect key="frame" x="16" y="156" width="382" height="100"/>
+                                                        <rect key="frame" x="16" y="156" width="1048" height="100"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="100" id="sl5-Xh-JVN"/>
                                                         </constraints>
@@ -3194,7 +3194,7 @@
                                                 <edgeInsets key="layoutMargins" top="0.0" left="16" bottom="0.0" right="16"/>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="H7N-kK-Eg8">
-                                                <rect key="frame" x="0.0" y="1208" width="414" height="77"/>
+                                                <rect key="frame" x="0.0" y="1179" width="1080" height="77"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Wr8-xd-PFv">
                                                         <rect key="frame" x="16" y="32" width="47" height="29"/>
@@ -3207,10 +3207,10 @@
                                                         </connections>
                                                     </button>
                                                     <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="6md-d9-MNf">
-                                                        <rect key="frame" x="78" y="44.5" width="258" height="4"/>
+                                                        <rect key="frame" x="78" y="44.5" width="924" height="4"/>
                                                     </progressView>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dA6-ol-M7f">
-                                                        <rect key="frame" x="351" y="32" width="47" height="29"/>
+                                                        <rect key="frame" x="1017" y="32" width="47" height="29"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <state key="normal" title="Upload">
                                                             <color key="titleColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
@@ -3308,11 +3308,11 @@
             <objects>
                 <viewController storyboardIdentifier="ua_menu_vc" id="Lba-J3-7h3" customClass="UserAccountMenuViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="n2J-fL-SRU">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zp4-gT-NHC">
-                                <rect key="frame" x="135" y="92" width="275" height="376"/>
+                                <rect key="frame" x="801" y="48" width="275" height="376"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="EN4-xR-Dob">
                                         <rect key="frame" x="0.0" y="0.0" width="275" height="376"/>
@@ -3583,18 +3583,18 @@
             <objects>
                 <viewController storyboardIdentifier="channel_manager_vc" id="OwO-Nt-Rqu" customClass="ChannelManagerViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5Oo-JK-N7M">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="k8q-aN-IZw">
-                                <rect key="frame" x="0.0" y="108" width="414" height="754"/>
+                                <rect key="frame" x="0.0" y="64" width="1080" height="746"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="channel_list_cell" id="kgm-RZ-33Q" customClass="ChannelListTableViewCell" customModule="Odysee" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="414" height="106.5"/>
+                                        <rect key="frame" x="0.0" y="28" width="1080" height="106.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="kgm-RZ-33Q" id="Jhg-ba-hlM">
-                                            <rect key="frame" x="0.0" y="0.0" width="383" height="106.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="1053" height="106.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="qhh-8v-8xX">
@@ -3605,22 +3605,22 @@
                                                     </constraints>
                                                 </imageView>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Vua-Bt-rSB">
-                                                    <rect key="frame" x="122" y="-26" width="245" height="158.5"/>
+                                                    <rect key="frame" x="122" y="-26" width="915" height="158.5"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3D4-fX-NHA">
-                                                            <rect key="frame" x="0.0" y="0.0" width="245" height="50.5"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="915" height="50.5"/>
                                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YHn-OL-gxx">
-                                                            <rect key="frame" x="0.0" y="54.5" width="245" height="50"/>
+                                                            <rect key="frame" x="0.0" y="54.5" width="915" height="50"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                             <color key="textColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6m0-cG-oWS">
-                                                            <rect key="frame" x="0.0" y="108.5" width="245" height="50"/>
+                                                            <rect key="frame" x="0.0" y="108.5" width="915" height="50"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -3628,7 +3628,7 @@
                                                     </subviews>
                                                 </stackView>
                                                 <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="New Channel..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SOD-1K-T4Q">
-                                                    <rect key="frame" x="122" y="43" width="245" height="20.5"/>
+                                                    <rect key="frame" x="122" y="43" width="915" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -3662,7 +3662,7 @@
                                 </connections>
                             </tableView>
                             <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="wPJ-51-tq9">
-                                <rect key="frame" x="107" y="292.5" width="200" height="311.5"/>
+                                <rect key="frame" x="440" y="249.5" width="200" height="311.5"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="spaceman_happy" translatesAutoresizingMaskIntoConstraints="NO" id="8sI-B5-PXI">
                                         <rect key="frame" x="0.0" y="0.0" width="200" height="200"/>
@@ -3693,7 +3693,7 @@
                                 </constraints>
                             </stackView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7E2-k7-4Mb" userLabel="Page Title Area">
-                                <rect key="frame" x="0.0" y="44" width="414" height="48"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="48"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XtA-KE-5Gn">
                                         <rect key="frame" x="0.0" y="0.0" width="48" height="48"/>
@@ -3736,7 +3736,7 @@
                                 </constraints>
                             </view>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2Ox-oZ-16z">
-                                <rect key="frame" x="175" y="416" width="64" height="64"/>
+                                <rect key="frame" x="508" y="373" width="64" height="64"/>
                                 <subviews>
                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="cls-Yr-cdZ">
                                         <rect key="frame" x="13.5" y="13.5" width="37" height="37"/>
@@ -3789,14 +3789,14 @@
             <objects>
                 <viewController storyboardIdentifier="channel_editor_vc" id="ZpA-3Q-B8s" customClass="ChannelEditorViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="hej-Sk-f74">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vif-Vl-UzT" userLabel="Top Area View">
-                                <rect key="frame" x="0.0" y="44" width="414" height="200"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="200"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="spaceman_cover" translatesAutoresizingMaskIntoConstraints="NO" id="1Uu-FF-apS">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="200"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="1080" height="200"/>
                                         <gestureRecognizers/>
                                         <connections>
                                             <outletCollection property="gestureRecognizers" destination="xUh-TY-QrQ" appends="YES" id="6jS-5i-rpw"/>
@@ -3861,7 +3861,7 @@
                                 </constraints>
                             </view>
                             <imageView clipsSubviews="YES" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="spaceman" translatesAutoresizingMaskIntoConstraints="NO" id="Rax-qA-xTx">
-                                <rect key="frame" x="167" y="204" width="80" height="80"/>
+                                <rect key="frame" x="500" y="160" width="80" height="80"/>
                                 <color key="backgroundColor" red="0.98039215686274506" green="0.38039215686274508" blue="0.396078431372549" alpha="1" colorSpace="calibratedRGB"/>
                                 <gestureRecognizers/>
                                 <constraints>
@@ -3873,7 +3873,7 @@
                                 </connections>
                             </imageView>
                             <view userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3jt-zw-qJ0" userLabel="Thumbnail Edit Container">
-                                <rect key="frame" x="189" y="240" width="36" height="36"/>
+                                <rect key="frame" x="522" y="196" width="36" height="36"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="pencil" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Hcb-f5-ggD">
                                         <rect key="frame" x="6" y="8.5" width="24" height="19.5"/>
@@ -3893,22 +3893,22 @@
                                 </constraints>
                             </view>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PaG-zY-5Jv">
-                                <rect key="frame" x="0.0" y="300" width="414" height="562"/>
+                                <rect key="frame" x="0.0" y="256" width="1080" height="554"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="jKl-AR-7w4">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="464"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="1080" height="464"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="5bv-Ro-5kc">
-                                                <rect key="frame" x="16" y="16" width="382" height="54"/>
+                                                <rect key="frame" x="16" y="16" width="1048" height="54"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DbW-xp-ms6">
-                                                        <rect key="frame" x="0.0" y="0.0" width="382" height="16"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="1048" height="16"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="DC2-va-Kzi">
-                                                        <rect key="frame" x="0.0" y="20" width="382" height="34"/>
+                                                        <rect key="frame" x="0.0" y="20" width="1048" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                         <textInputTraits key="textInputTraits"/>
                                                         <connections>
@@ -3919,16 +3919,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="p8u-Dw-6T5">
-                                                <rect key="frame" x="16" y="86" width="382" height="54"/>
+                                                <rect key="frame" x="16" y="86" width="1048" height="54"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Channel Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d8p-Dd-oj3">
-                                                        <rect key="frame" x="0.0" y="0.0" width="382" height="16"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="1048" height="16"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="@channel" textAlignment="natural" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="O6a-0a-Kxg">
-                                                        <rect key="frame" x="0.0" y="20" width="382" height="34"/>
+                                                        <rect key="frame" x="0.0" y="20" width="1048" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                         <textInputTraits key="textInputTraits"/>
                                                         <connections>
@@ -3939,16 +3939,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="gfm-tk-xdV">
-                                                <rect key="frame" x="16" y="156" width="382" height="148"/>
+                                                <rect key="frame" x="16" y="156" width="1048" height="148"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Deposit" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HvO-I5-Dzk">
-                                                        <rect key="frame" x="0.0" y="0.0" width="382" height="16"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="1048" height="16"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hzj-yQ-sTx">
-                                                        <rect key="frame" x="0.0" y="20" width="382" height="128"/>
+                                                        <rect key="frame" x="0.0" y="20" width="1048" height="128"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="credits_icon" translatesAutoresizingMaskIntoConstraints="NO" id="RUY-Mj-8Ay">
                                                                 <rect key="frame" x="0.0" y="56" width="16" height="16"/>
@@ -3981,19 +3981,19 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="fVb-wy-N7i" userLabel="Optional Fields">
-                                                <rect key="frame" x="16" y="312" width="382" height="108"/>
+                                                <rect key="frame" x="16" y="312" width="1048" height="108"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="qkP-Sa-OLh">
-                                                        <rect key="frame" x="0.0" y="0.0" width="382" height="68"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="1048" height="68"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Description" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9be-r5-cmS">
-                                                                <rect key="frame" x="0.0" y="0.0" width="382" height="0.0"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="1048" height="0.0"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="co3-Mn-sAk">
-                                                                <rect key="frame" x="0.0" y="4" width="382" height="64"/>
+                                                                <rect key="frame" x="0.0" y="4" width="1048" height="64"/>
                                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="64" id="kBb-9m-Xkc"/>
@@ -4005,16 +4005,16 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="qtb-NC-kvK">
-                                                        <rect key="frame" x="0.0" y="84" width="382" height="4"/>
+                                                        <rect key="frame" x="0.0" y="84" width="1048" height="4"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Website" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WlV-qB-ON4">
-                                                                <rect key="frame" x="0.0" y="0.0" width="382" height="0.0"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="1048" height="0.0"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="hsp-96-Dh9">
-                                                                <rect key="frame" x="0.0" y="4" width="382" height="0.0"/>
+                                                                <rect key="frame" x="0.0" y="4" width="1048" height="0.0"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                                 <connections>
@@ -4025,16 +4025,16 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="iZx-Xa-HcA">
-                                                        <rect key="frame" x="0.0" y="104" width="382" height="4"/>
+                                                        <rect key="frame" x="0.0" y="104" width="1048" height="4"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Email" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Eej-q3-EVZ">
-                                                                <rect key="frame" x="0.0" y="0.0" width="382" height="0.0"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="1048" height="0.0"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="nkd-N0-XFi">
-                                                                <rect key="frame" x="0.0" y="4" width="382" height="0.0"/>
+                                                                <rect key="frame" x="0.0" y="4" width="1048" height="0.0"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                                 <connections>
@@ -4047,7 +4047,7 @@
                                                 </subviews>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5LR-XD-gRd" userLabel="Buttons Area">
-                                                <rect key="frame" x="16" y="320" width="382" height="128"/>
+                                                <rect key="frame" x="16" y="320" width="1048" height="128"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lUA-Hl-nQT">
                                                         <rect key="frame" x="0.0" y="32" width="45" height="96"/>
@@ -4060,7 +4060,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="10E-NI-CLd">
-                                                        <rect key="frame" x="188" y="32" width="130" height="29"/>
+                                                        <rect key="frame" x="854" y="32" width="130" height="29"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <state key="normal" title="Show optional fields"/>
                                                         <connections>
@@ -4068,7 +4068,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bfu-gf-aa2">
-                                                        <rect key="frame" x="350" y="32" width="32" height="96"/>
+                                                        <rect key="frame" x="1016" y="32" width="32" height="96"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <state key="normal" title="Save">
                                                             <color key="titleColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
@@ -4078,7 +4078,7 @@
                                                         </connections>
                                                     </button>
                                                     <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="VSC-nJ-wRj">
-                                                        <rect key="frame" x="314" y="36" width="20" height="20"/>
+                                                        <rect key="frame" x="980" y="36" width="20" height="20"/>
                                                         <color key="color" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                                     </activityIndicatorView>
                                                 </subviews>
@@ -4109,7 +4109,7 @@
                                 </constraints>
                             </scrollView>
                             <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="VDJ-gm-CcO">
-                                <rect key="frame" x="301.5" y="252" width="96.5" height="30"/>
+                                <rect key="frame" x="967.5" y="208" width="96.5" height="30"/>
                                 <subviews>
                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="LN5-EA-JFd">
                                         <rect key="frame" x="0.0" y="0.0" width="20" height="30"/>
@@ -4189,14 +4189,14 @@
             <objects>
                 <viewController storyboardIdentifier="rewards_vc" id="3P2-O8-coP" customClass="RewardsViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="mJa-e0-ije">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f4G-qd-V3K">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                                 <subviews>
                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="4yE-Li-h1m">
-                                        <rect key="frame" x="188.5" y="390.5" width="37" height="37"/>
+                                        <rect key="frame" x="521.5" y="386.5" width="37" height="37"/>
                                         <color key="color" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                     </activityIndicatorView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Reward Verification" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KZ5-Sh-qXy">
@@ -4206,16 +4206,16 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="You are not reward eligible. Join the Odysee Rewards Program today using one of these options." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PXl-lf-pkR">
-                                        <rect key="frame" x="32" y="149.5" width="350" height="54"/>
+                                        <rect key="frame" x="32" y="149.5" width="1016" height="18"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="jcx-mU-gUY">
-                                        <rect key="frame" x="32" y="235.5" width="350" height="171.5"/>
+                                        <rect key="frame" x="32" y="199.5" width="1016" height="199.5"/>
                                         <subviews>
                                             <button opaque="NO" tag="100" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Z5b-Kj-bFn">
-                                                <rect key="frame" x="0.0" y="0.0" width="82.5" height="171.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="239.5" height="199.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <state key="normal" title="Twitter">
                                                     <color key="titleColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
@@ -4225,7 +4225,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" tag="101" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lbT-cr-TN3">
-                                                <rect key="frame" x="82.5" y="0.0" width="181.5" height="171.5"/>
+                                                <rect key="frame" x="239.5" y="0.0" width="526.5" height="199.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <state key="normal" title="Skip the Queue"/>
                                                 <connections>
@@ -4233,7 +4233,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" tag="102" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rne-eG-gXD">
-                                                <rect key="frame" x="264" y="0.0" width="86" height="171.5"/>
+                                                <rect key="frame" x="766" y="0.0" width="250" height="199.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <state key="normal" title="Manual"/>
                                                 <connections>
@@ -4243,23 +4243,23 @@
                                         </subviews>
                                     </stackView>
                                     <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PgO-Yv-XiL">
-                                        <rect key="frame" x="0.0" y="423" width="414" height="395"/>
+                                        <rect key="frame" x="0.0" y="415" width="1080" height="395"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="u36-tj-Ii8" userLabel="Scrolling Stack View">
-                                                <rect key="frame" x="0.0" y="0.0" width="1242" height="395"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="3240" height="395"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="I4H-Yj-zMI">
-                                                        <rect key="frame" x="0.0" y="0.0" width="414" height="395"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="1080" height="395"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ADJ-Nx-aDk">
-                                                                <rect key="frame" x="32" y="0.0" width="350" height="72"/>
+                                                                <rect key="frame" x="32" y="0.0" width="1016" height="36"/>
                                                                 <string key="text">Get instantly verified using your Twitter account. Your Twitter email address must match the email that you provided, and your account should be active.</string>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jaM-8A-pPk">
-                                                                <rect key="frame" x="141.5" y="104" width="131" height="32"/>
+                                                                <rect key="frame" x="474.5" y="68" width="131" height="32"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                 <state key="normal" title="Verify with Twitter">
                                                                     <color key="titleColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
@@ -4279,16 +4279,16 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d7a-wG-csz">
-                                                        <rect key="frame" x="414" y="0.0" width="414" height="395"/>
+                                                        <rect key="frame" x="1080" y="0.0" width="1080" height="395"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Skip the manual verification queue by paying a fee in order to start participating in the rewards program immediately." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9A8-cs-RMm">
-                                                                <rect key="frame" x="32" y="0.0" width="350" height="54"/>
+                                                                <rect key="frame" x="32" y="0.0" width="1016" height="18"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Cb0-xp-4aw">
-                                                                <rect key="frame" x="158.5" y="86" width="97" height="30"/>
+                                                                <rect key="frame" x="491.5" y="50" width="97" height="30"/>
                                                                 <state key="normal" title="Skip for $4.99">
                                                                     <color key="titleColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                                                 </state>
@@ -4307,23 +4307,23 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iR7-PH-ioE">
-                                                        <rect key="frame" x="828" y="0.0" width="414" height="395"/>
+                                                        <rect key="frame" x="2160" y="0.0" width="1080" height="395"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uta-5a-feI">
-                                                                <rect key="frame" x="32" y="0.0" width="350" height="54"/>
+                                                                <rect key="frame" x="32" y="0.0" width="1016" height="18"/>
                                                                 <string key="text">Please request to be verified on the LBRY Foundation Discord server. A manual review can take anywhere from several minutes to a few days.</string>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="You can continue to enjoy content in the meantime!" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qMz-nM-Zdp">
-                                                                <rect key="frame" x="32" y="70" width="350" height="36"/>
+                                                                <rect key="frame" x="32" y="34" width="1016" height="18"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="O2C-Fs-31Q">
-                                                                <rect key="frame" x="176" y="138" width="62" height="30"/>
+                                                                <rect key="frame" x="509" y="84" width="62" height="30"/>
                                                                 <state key="normal" title="Continue">
                                                                     <color key="titleColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                                                 </state>
@@ -4394,23 +4394,23 @@
                                 </constraints>
                             </view>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="z8a-nY-gHE">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Reward Verified" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="43u-ib-fIy">
-                                        <rect key="frame" x="32" y="112" width="350" height="21.5"/>
+                                        <rect key="frame" x="32" y="112" width="1016" height="21.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="spaceman_happy" translatesAutoresizingMaskIntoConstraints="NO" id="U0j-HX-U6R">
-                                        <rect key="frame" x="107" y="197.5" width="200" height="200"/>
+                                        <rect key="frame" x="440" y="197.5" width="200" height="200"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="200" id="OY3-G8-Hsq"/>
                                             <constraint firstAttribute="width" constant="200" id="OpH-La-8kW"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Congratulations! You are reward eligible. Available rewards can be viewed and claimed on the Odysee web site." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ygs-mt-oXy">
-                                        <rect key="frame" x="32" y="429.5" width="350" height="54"/>
+                                        <rect key="frame" x="32" y="429.5" width="1016" height="18"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -4440,10 +4440,10 @@
                                 </constraints>
                             </view>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a4E-H0-Fw3">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Sa0-1U-a10" userLabel="Page Title Area">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="48"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="1080" height="48"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="e22-fx-m3x">
                                                 <rect key="frame" x="0.0" y="0.0" width="48" height="48"/>
@@ -4486,7 +4486,7 @@
                                         </constraints>
                                     </view>
                                     <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="1" translatesAutoresizingMaskIntoConstraints="NO" id="AvX-Mf-FdW">
-                                        <rect key="frame" x="16" y="48" width="382" height="32"/>
+                                        <rect key="frame" x="16" y="48" width="1048" height="32"/>
                                         <segments>
                                             <segment title="All"/>
                                             <segment title="Unclaimed"/>
@@ -4497,31 +4497,31 @@
                                         </connections>
                                     </segmentedControl>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Nld-Sb-ZNj">
-                                        <rect key="frame" x="0.0" y="79" width="414" height="739"/>
+                                        <rect key="frame" x="0.0" y="79" width="1080" height="731"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="reward_cell" id="ays-6j-gVd" customClass="RewardTableViewCell" customModule="Odysee" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="28" width="414" height="70.5"/>
+                                                <rect key="frame" x="0.0" y="28" width="1080" height="70.5"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ays-6j-gVd" id="RZe-bZ-Yrh">
-                                                    <rect key="frame" x="0.0" y="0.0" width="414" height="70.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="1080" height="70.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wHA-aE-RRq">
-                                                            <rect key="frame" x="16" y="19" width="301" height="18"/>
+                                                            <rect key="frame" x="16" y="19" width="967" height="18"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                             <color key="textColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1oj-83-ZJo">
-                                                            <rect key="frame" x="16" y="4" width="301" height="16.5"/>
+                                                            <rect key="frame" x="16" y="4" width="967" height="16.5"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="x48-wO-3V7">
-                                                            <rect key="frame" x="333" y="13" width="65" height="44.5"/>
+                                                            <rect key="frame" x="999" y="13" width="65" height="44.5"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="up to" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Yv-TE-R1p">
                                                                     <rect key="frame" x="19" y="0.0" width="27" height="13.5"/>
@@ -4592,7 +4592,7 @@
                                         </connections>
                                     </tableView>
                                     <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SG4-Jq-R7o">
-                                        <rect key="frame" x="175" y="377" width="64" height="64"/>
+                                        <rect key="frame" x="508" y="373" width="64" height="64"/>
                                         <subviews>
                                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="eQf-XS-ACc">
                                                 <rect key="frame" x="13.5" y="13.5" width="37" height="37"/>
@@ -4608,7 +4608,7 @@
                                         </constraints>
                                     </view>
                                     <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="xEL-Gy-rCT">
-                                        <rect key="frame" x="107" y="280.5" width="200" height="257.5"/>
+                                        <rect key="frame" x="440" y="276.5" width="200" height="257.5"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="spaceman_sad" translatesAutoresizingMaskIntoConstraints="NO" id="rMM-ON-OSw">
                                                 <rect key="frame" x="0.0" y="0.0" width="200" height="200"/>
@@ -4649,7 +4649,7 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="close" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7Ob-04-3r8">
-                                <rect key="frame" x="368" y="60" width="30" height="30"/>
+                                <rect key="frame" x="1034" y="16" width="30" height="30"/>
                                 <connections>
                                     <action selector="closeTappedWith_sender:" destination="3P2-O8-coP" eventType="touchUpInside" id="lNg-WY-Isy"/>
                                 </connections>
@@ -4706,15 +4706,15 @@
             <objects>
                 <viewController storyboardIdentifier="go_live_vc" id="fov-pz-LOs" customClass="GoLiveViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="cMA-ww-5a5">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jw0-hm-bp1" userLabel="Camera Capture Display View">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="u3y-nj-oLx" userLabel="Change Camera button">
-                                <rect key="frame" x="373.5" y="776" width="24.5" height="22"/>
+                                <rect key="frame" x="1039.5" y="724" width="24.5" height="22"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                 <state key="normal" image="arrow.triangle.2.circlepath.camera" catalog="system"/>
                                 <connections>
@@ -4722,32 +4722,32 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iuz-Xq-7OO">
-                                <rect key="frame" x="292" y="816" width="106" height="30"/>
+                                <rect key="frame" x="958" y="764" width="106" height="30"/>
                                 <state key="normal" title="Start streaming"/>
                                 <connections>
                                     <action selector="toggleStreamingTapped:" destination="fov-pz-LOs" eventType="touchUpInside" id="ILL-kD-Vu6"/>
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1or-Qw-Zdb">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                                 <subviews>
                                     <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5rl-Cv-Aqe">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="818"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="VAA-tu-Cok">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="466"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="1080" height="466"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="ZFB-os-hzL">
-                                                        <rect key="frame" x="16" y="64" width="382" height="112"/>
+                                                        <rect key="frame" x="16" y="64" width="1048" height="112"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Please select a channel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0KY-Gc-pAc">
-                                                                <rect key="frame" x="0.0" y="0.0" width="382" height="16"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="1048" height="16"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cmS-yj-G87">
-                                                                <rect key="frame" x="0.0" y="16" width="382" height="80"/>
+                                                                <rect key="frame" x="0.0" y="16" width="1048" height="80"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="80" id="ndK-35-JWL"/>
                                                                 </constraints>
@@ -4757,7 +4757,7 @@
                                                                 </connections>
                                                             </pickerView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gd5-Vo-rPh">
-                                                                <rect key="frame" x="0.0" y="96" width="382" height="16"/>
+                                                                <rect key="frame" x="0.0" y="96" width="1048" height="16"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <color key="textColor" systemColor="systemRedColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -4765,32 +4765,32 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="PHR-TQ-oxl">
-                                                        <rect key="frame" x="16" y="200" width="382" height="54"/>
+                                                        <rect key="frame" x="16" y="200" width="1048" height="54"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Please specify a title for your livestream" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Bof-VV-QBA">
-                                                                <rect key="frame" x="0.0" y="0.0" width="382" height="16"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="1048" height="16"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="q03-LB-HXE">
-                                                                <rect key="frame" x="0.0" y="20" width="382" height="34"/>
+                                                                <rect key="frame" x="0.0" y="20" width="1048" height="34"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Spj-dA-4Zt" userLabel="Thumbnail Area">
-                                                        <rect key="frame" x="16" y="278" width="382" height="126"/>
+                                                        <rect key="frame" x="16" y="278" width="1048" height="126"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Please select a thumbnail" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DeV-V7-lSf" userLabel="Thumbnail">
-                                                                <rect key="frame" x="0.0" y="0.0" width="382" height="16"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="1048" height="16"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QRr-jG-FPg">
-                                                                <rect key="frame" x="0.0" y="20" width="382" height="106"/>
+                                                                <rect key="frame" x="0.0" y="20" width="1048" height="106"/>
                                                                 <subviews>
                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="spaceman" translatesAutoresizingMaskIntoConstraints="NO" id="GEv-CB-bUp">
                                                                         <rect key="frame" x="0.0" y="8" width="160" height="90"/>
@@ -4820,10 +4820,10 @@
                                                                         <edgeInsets key="layoutMargins" top="0.0" left="8" bottom="0.0" right="8"/>
                                                                     </stackView>
                                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="75q-Z2-ctd">
-                                                                        <rect key="frame" x="176" y="8" width="206" height="28"/>
+                                                                        <rect key="frame" x="176" y="8" width="872" height="28"/>
                                                                         <subviews>
                                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2dW-uN-M1y">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="206" height="28"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="872" height="28"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                                 <state key="normal" title="Select an image">
                                                                                     <color key="titleColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
@@ -4851,7 +4851,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WA2-Ib-g9c">
-                                                        <rect key="frame" x="16" y="428" width="382" height="30"/>
+                                                        <rect key="frame" x="16" y="428" width="1048" height="30"/>
                                                         <state key="normal" title="Continue">
                                                             <color key="titleColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                                         </state>
@@ -4881,17 +4881,17 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aA3-Qn-14h" userLabel="Pre-load View">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="spaceman_happy" translatesAutoresizingMaskIntoConstraints="NO" id="fAJ-vz-RjM">
-                                        <rect key="frame" x="87" y="289" width="240" height="240"/>
+                                        <rect key="frame" x="420" y="285" width="240" height="240"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="240" id="RmO-Um-c1U"/>
                                             <constraint firstAttribute="height" constant="240" id="vE4-jw-28a"/>
                                         </constraints>
                                     </imageView>
                                     <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vpd-L9-xeu">
-                                        <rect key="frame" x="175" y="377" width="64" height="64"/>
+                                        <rect key="frame" x="508" y="373" width="64" height="64"/>
                                         <subviews>
                                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="e0Z-9k-RPD">
                                                 <rect key="frame" x="13.5" y="13.5" width="37" height="37"/>
@@ -4907,7 +4907,7 @@
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Please wait while we check a few things. If this is your first time, this may take a couple of minutes..." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bY1-OR-IR2">
-                                        <rect key="frame" x="32" y="561" width="350" height="33.5"/>
+                                        <rect key="frame" x="32" y="557" width="1016" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -4925,7 +4925,7 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="close" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ffe-rT-rxC" userLabel="Close Button">
-                                <rect key="frame" x="368" y="60" width="30" height="30"/>
+                                <rect key="frame" x="1034" y="16" width="30" height="30"/>
                                 <connections>
                                     <action selector="closeTapped:" destination="fov-pz-LOs" eventType="touchUpInside" id="adG-xp-eFz"/>
                                 </connections>
@@ -4979,11 +4979,11 @@
             <objects>
                 <viewController storyboardIdentifier="support_vc" id="Bmo-dA-8B6" customClass="SupportViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="79S-i1-daX">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xC4-p6-l6i" userLabel="Content View">
-                                <rect key="frame" x="0.0" y="502" width="414" height="360"/>
+                                <rect key="frame" x="0.0" y="466.5" width="1080" height="343.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Support" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ogd-Vs-2JH">
                                         <rect key="frame" x="16" y="16" width="65.5" height="21.5"/>
@@ -4996,22 +4996,22 @@
                                         <color key="color" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                     </activityIndicatorView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Show this channel your appreciation by sending a donation." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cbY-1n-seA">
-                                        <rect key="frame" x="16" y="45.5" width="382" height="33.5"/>
+                                        <rect key="frame" x="16" y="45.5" width="1048" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Channel to show support as" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zf2-sT-75U">
-                                        <rect key="frame" x="16" y="95" width="382" height="17"/>
+                                        <rect key="frame" x="16" y="78.5" width="1048" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TDb-N3-HvI" userLabel="Segment View">
-                                        <rect key="frame" x="16" y="256" width="382" height="36"/>
+                                        <rect key="frame" x="16" y="239.5" width="1048" height="36"/>
                                         <subviews>
                                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="MCK-ju-xGy">
-                                                <rect key="frame" x="20" y="2.5" width="362" height="32"/>
+                                                <rect key="frame" x="20" y="2.5" width="1028" height="32"/>
                                                 <segments>
                                                     <segment title="5"/>
                                                     <segment title="25"/>
@@ -5042,7 +5042,7 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3tT-ok-snK" userLabel="Controls View">
-                                        <rect key="frame" x="16" y="308" width="382" height="36"/>
+                                        <rect key="frame" x="16" y="291.5" width="1048" height="36"/>
                                         <subviews>
                                             <textField hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Amount" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="OE2-Vp-AcU">
                                                 <rect key="frame" x="20" y="1" width="72" height="34"/>
@@ -5057,7 +5057,7 @@
                                                 </connections>
                                             </textField>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZaB-wV-g0w">
-                                                <rect key="frame" x="301" y="3.5" width="81" height="29"/>
+                                                <rect key="frame" x="967" y="3.5" width="81" height="29"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <state key="normal" title="Tip 5 credits">
                                                     <color key="titleColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
@@ -5077,7 +5077,7 @@
                                         </constraints>
                                     </view>
                                     <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9gk-0X-bDz">
-                                        <rect key="frame" x="0.0" y="120" width="414" height="120"/>
+                                        <rect key="frame" x="0.0" y="103.5" width="1080" height="120"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="120" id="dnr-B1-j59"/>
                                         </constraints>
@@ -5087,7 +5087,7 @@
                                         </connections>
                                     </pickerView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="close" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="39F-qX-May">
-                                        <rect key="frame" x="368" y="11" width="30" height="30"/>
+                                        <rect key="frame" x="1034" y="11" width="30" height="30"/>
                                         <connections>
                                             <action selector="closeTapped:" destination="Bmo-dA-8B6" eventType="touchUpInside" id="odG-qe-9VJ"/>
                                         </connections>
@@ -5190,14 +5190,14 @@
             <objects>
                 <viewController storyboardIdentifier="channel_view_vc" id="UG4-ee-FIj" customClass="ChannelViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="oKg-JB-AXJ">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZuB-Uj-9J8" userLabel="Top Area View">
-                                <rect key="frame" x="0.0" y="44" width="414" height="200"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="200"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="6Qe-hM-EJd">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="200"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="1080" height="200"/>
                                     </imageView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UF3-7v-QZm">
                                         <rect key="frame" x="0.0" y="0.0" width="48" height="48"/>
@@ -5224,17 +5224,17 @@
                                         </connections>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="7In-XE-JGO">
-                                        <rect key="frame" x="112" y="164.5" width="286" height="19.5"/>
+                                        <rect key="frame" x="112" y="164.5" width="952" height="19.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QpJ-Yt-tWm" customClass="UIPaddedLabel" customModule="Odysee" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="0.0" width="286" height="19.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="952" height="19.5"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0 followers" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b7j-hZ-Bkt" customClass="UIPaddedLabel" customModule="Odysee" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="0.0" width="286" height="0.0"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="952" height="0.0"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="0.84705882349999995" colorSpace="calibratedRGB"/>
@@ -5257,10 +5257,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JRX-0j-K1Q" userLabel="Actions Area View">
-                                <rect key="frame" x="0.0" y="244" width="414" height="60"/>
+                                <rect key="frame" x="0.0" y="200" width="1080" height="60"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2Kf-NB-26Y">
-                                        <rect key="frame" x="247.5" y="0.0" width="166.5" height="60"/>
+                                        <rect key="frame" x="913.5" y="0.0" width="166.5" height="60"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oYo-hX-j9P" userLabel="Share Container View">
                                                 <rect key="frame" x="0.0" y="0.0" width="60" height="60"/>
@@ -5371,7 +5371,7 @@
                                 </constraints>
                             </view>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="iDo-Pq-16l">
-                                <rect key="frame" x="16" y="204" width="80" height="80"/>
+                                <rect key="frame" x="16" y="160" width="80" height="80"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="80" id="0aW-gq-vOf"/>
                                     <constraint firstAttribute="height" constant="80" id="Ec8-IL-SMb"/>
@@ -5380,16 +5380,16 @@
                                 </constraints>
                             </imageView>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" bounces="NO" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ewa-ON-DbC">
-                                <rect key="frame" x="0.0" y="304" width="414" height="340"/>
+                                <rect key="frame" x="0.0" y="260" width="1080" height="340"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VDX-Qs-059">
-                                        <rect key="frame" x="0.0" y="0.0" width="1242" height="340"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="3240" height="340"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ASP-rk-fY4" userLabel="Channel Content Page">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="340"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="1080" height="340"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8J8-eq-4C3" userLabel="Sort Options View">
-                                                        <rect key="frame" x="16" y="0.0" width="382" height="24"/>
+                                                        <rect key="frame" x="16" y="0.0" width="1048" height="24"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="hFc-fW-6Pw">
                                                                 <rect key="frame" x="0.0" y="0.0" width="39.5" height="24"/>
@@ -5429,7 +5429,7 @@
                                                         </constraints>
                                                     </view>
                                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="JMO-Ak-qdM">
-                                                        <rect key="frame" x="0.0" y="32" width="414" height="308"/>
+                                                        <rect key="frame" x="0.0" y="32" width="1080" height="308"/>
                                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                         <connections>
                                                             <outlet property="dataSource" destination="UG4-ee-FIj" id="Ccx-Pv-YoU"/>
@@ -5437,7 +5437,7 @@
                                                         </connections>
                                                     </tableView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="OTo-h2-wfs">
-                                                        <rect key="frame" x="107" y="41.5" width="200" height="257.5"/>
+                                                        <rect key="frame" x="440" y="41.5" width="200" height="257.5"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="spaceman_sad" translatesAutoresizingMaskIntoConstraints="NO" id="b4i-T6-2Gf">
                                                                 <rect key="frame" x="0.0" y="0.0" width="200" height="200"/>
@@ -5459,7 +5459,7 @@
                                                         </constraints>
                                                     </stackView>
                                                     <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LiB-Kb-5V3">
-                                                        <rect key="frame" x="175" y="138" width="64" height="64"/>
+                                                        <rect key="frame" x="508" y="138" width="64" height="64"/>
                                                         <subviews>
                                                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="aTT-EH-zWD">
                                                                 <rect key="frame" x="13.5" y="13.5" width="37" height="37"/>
@@ -5491,25 +5491,25 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7UP-Ym-HvX" userLabel="Channel About Page">
-                                                <rect key="frame" x="414" y="0.0" width="414" height="340"/>
+                                                <rect key="frame" x="1080" y="0.0" width="1080" height="340"/>
                                                 <subviews>
                                                     <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cJU-mh-gl2">
-                                                        <rect key="frame" x="0.0" y="0.0" width="414" height="340"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="1080" height="340"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="9Pf-i1-fhG">
-                                                                <rect key="frame" x="0.0" y="0.0" width="414" height="185"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="1080" height="185"/>
                                                                 <subviews>
                                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="7Ux-aN-qWB">
-                                                                        <rect key="frame" x="16" y="0.0" width="382" height="68.5"/>
+                                                                        <rect key="frame" x="16" y="0.0" width="1048" height="68.5"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Website" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XDD-T5-BQT">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="382" height="14.5"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="1048" height="14.5"/>
                                                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cCY-76-oRo">
-                                                                                <rect key="frame" x="0.0" y="18.5" width="382" height="50"/>
+                                                                                <rect key="frame" x="0.0" y="18.5" width="1048" height="50"/>
                                                                                 <gestureRecognizers/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                                 <color key="textColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
@@ -5521,16 +5521,16 @@
                                                                         </subviews>
                                                                     </stackView>
                                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="mch-iA-YOS">
-                                                                        <rect key="frame" x="16" y="84.5" width="382" height="68.5"/>
+                                                                        <rect key="frame" x="16" y="84.5" width="1048" height="68.5"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Email" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EKe-e0-aAt">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="382" height="14.5"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="1048" height="14.5"/>
                                                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cSI-oV-YfW">
-                                                                                <rect key="frame" x="0.0" y="18.5" width="382" height="50"/>
+                                                                                <rect key="frame" x="0.0" y="18.5" width="1048" height="50"/>
                                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                                 <color key="textColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                                                                 <nil key="highlightedColor"/>
@@ -5538,7 +5538,7 @@
                                                                         </subviews>
                                                                     </stackView>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8aG-Dk-1e1">
-                                                                        <rect key="frame" x="16" y="169" width="382" height="0.0"/>
+                                                                        <rect key="frame" x="16" y="169" width="1048" height="0.0"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
@@ -5556,7 +5556,7 @@
                                                         </constraints>
                                                     </scrollView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="3NS-hi-TsL">
-                                                        <rect key="frame" x="107" y="41.5" width="200" height="257.5"/>
+                                                        <rect key="frame" x="440" y="41.5" width="200" height="257.5"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="spaceman_sad" translatesAutoresizingMaskIntoConstraints="NO" id="k3s-z8-JOH">
                                                                 <rect key="frame" x="0.0" y="0.0" width="200" height="200"/>
@@ -5589,7 +5589,7 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8fQ-ED-iLM" userLabel="Channel Community Page">
-                                                <rect key="frame" x="828" y="0.0" width="414" height="340"/>
+                                                <rect key="frame" x="2160" y="0.0" width="1080" height="340"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             </view>
                                         </subviews>
@@ -5607,7 +5607,7 @@
                                 </connections>
                             </scrollView>
                             <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="PRD-sq-gU2">
-                                <rect key="frame" x="146" y="644" width="122.5" height="218"/>
+                                <rect key="frame" x="479" y="600" width="122.5" height="210"/>
                                 <color key="pageIndicatorTintColor" systemColor="systemGrayColor"/>
                                 <color key="currentPageIndicatorTintColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                 <connections>
@@ -5615,10 +5615,10 @@
                                 </connections>
                             </pageControl>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BgM-Yd-RRr" userLabel="Resolving Content View">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2hf-Kn-zb1">
-                                        <rect key="frame" x="87" y="229" width="240" height="360"/>
+                                        <rect key="frame" x="420" y="225" width="240" height="360"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="spaceman_happy" translatesAutoresizingMaskIntoConstraints="NO" id="FU2-j5-4eC">
                                                 <rect key="frame" x="20" y="56.5" width="200" height="240"/>
@@ -5650,7 +5650,7 @@
                                         </constraints>
                                     </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="close" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ch5-Kt-76i">
-                                        <rect key="frame" x="368" y="16" width="30" height="30"/>
+                                        <rect key="frame" x="1034" y="16" width="30" height="30"/>
                                         <connections>
                                             <action selector="closeTapped:" destination="Wx8-f6-Mvh" eventType="touchUpInside" id="7ql-hX-il8"/>
                                             <action selector="closeTapped:" destination="UG4-ee-FIj" eventType="touchUpInside" id="H2k-sz-tXu"/>
@@ -5781,20 +5781,20 @@
             <objects>
                 <viewController storyboardIdentifier="file_view_vc" modalPresentationStyle="fullScreen" id="Wx8-f6-Mvh" customClass="FileViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="u0E-KJ-ZkJ">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hZs-fq-qQ6">
-                                <rect key="frame" x="0.0" y="44" width="414" height="240"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="240"/>
                                 <subviews>
                                     <imageView hidden="YES" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="streaming_odysee" translatesAutoresizingMaskIntoConstraints="NO" id="b5M-lr-1ir">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="240"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="1080" height="240"/>
                                     </imageView>
                                     <view hidden="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DED-pq-EGI">
-                                        <rect key="frame" x="4" y="212" width="406" height="24"/>
+                                        <rect key="frame" x="4" y="212" width="1072" height="24"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8PH-TD-6Ni">
-                                                <rect key="frame" x="8" y="4" width="390" height="16"/>
+                                                <rect key="frame" x="8" y="4" width="1056" height="16"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -5809,10 +5809,10 @@
                                         </constraints>
                                     </view>
                                     <view hidden="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FZX-xm-zP4">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="212"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="1080" height="212"/>
                                         <subviews>
                                             <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Loading content..." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Akm-Tw-w5H">
-                                                <rect key="frame" x="16" y="97.5" width="382" height="17"/>
+                                                <rect key="frame" x="16" y="97.5" width="1048" height="17"/>
                                                 <gestureRecognizers/>
                                                 <edgeInsets key="layoutMargins" top="8" left="24" bottom="8" right="24"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -5823,14 +5823,14 @@
                                                 </connections>
                                             </label>
                                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" animating="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="FEo-uC-JS9">
-                                                <rect key="frame" x="197" y="61.5" width="20" height="20"/>
+                                                <rect key="frame" x="530" y="61.5" width="20" height="20"/>
                                                 <color key="color" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                             </activityIndicatorView>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8wK-nh-Xt8">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="212"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="1080" height="212"/>
                                             </imageView>
                                             <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yOt-RI-fY3">
-                                                <rect key="frame" x="175" y="91.5" width="64" height="29"/>
+                                                <rect key="frame" x="508" y="91.5" width="64" height="29"/>
                                                 <color key="backgroundColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="64" id="oQQ-jN-LU1"/>
@@ -5882,10 +5882,10 @@
                                 </connections>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="J4Z-JJ-JZs" userLabel="Livestream Chat View">
-                                <rect key="frame" x="0.0" y="284" width="414" height="578"/>
+                                <rect key="frame" x="0.0" y="240" width="1080" height="570"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kiy-8R-Tvl" userLabel="Livestreamer Area">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="56"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="1080" height="56"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="1To-g8-Q9H">
                                                 <rect key="frame" x="16" y="8" width="40" height="40"/>
@@ -5895,16 +5895,16 @@
                                                 </constraints>
                                             </imageView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="ewK-1m-e3W" userLabel="Publisher Labels">
-                                                <rect key="frame" x="72" y="-22" width="218" height="100"/>
+                                                <rect key="frame" x="72" y="-22" width="884" height="100"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KPs-x6-FW7">
-                                                        <rect key="frame" x="0.0" y="0.0" width="218" height="50"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="884" height="50"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qy0-IS-SWO">
-                                                        <rect key="frame" x="0.0" y="50" width="218" height="50"/>
+                                                        <rect key="frame" x="0.0" y="50" width="884" height="50"/>
                                                         <gestureRecognizers/>
                                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="13"/>
                                                         <color key="textColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
@@ -5919,7 +5919,7 @@
                                                 </constraints>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nNF-Ha-rzf" userLabel="Publisher Area Actions">
-                                                <rect key="frame" x="313.5" y="16" width="100.5" height="24"/>
+                                                <rect key="frame" x="979.5" y="16" width="100.5" height="24"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="zhW-es-EfU" userLabel="Follow / Unfollow View">
                                                         <rect key="frame" x="0.0" y="0.0" width="100.5" height="24"/>
@@ -5991,14 +5991,14 @@
                                         </connections>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ows-0u-uaP" userLabel="Divider">
-                                        <rect key="frame" x="0.0" y="56" width="414" height="1"/>
+                                        <rect key="frame" x="0.0" y="56" width="1080" height="1"/>
                                         <color key="backgroundColor" systemColor="systemGray5Color"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="1" id="8Jo-Pj-6Wo"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sl5-Hh-7Fz" userLabel="Chat Title Area">
-                                        <rect key="frame" x="0.0" y="65" width="414" height="24"/>
+                                        <rect key="frame" x="0.0" y="65" width="1080" height="24"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Live discussion" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vWY-SP-cUz">
                                                 <rect key="frame" x="16" y="4" width="96.5" height="16"/>
@@ -6015,25 +6015,25 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FMh-2w-dwz" userLabel="Divider">
-                                        <rect key="frame" x="0.0" y="97" width="414" height="1"/>
+                                        <rect key="frame" x="0.0" y="97" width="1080" height="1"/>
                                         <color key="backgroundColor" systemColor="systemGray5Color"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="1" id="pgk-it-U0K"/>
                                         </constraints>
                                     </view>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="sdu-U2-NfY">
-                                        <rect key="frame" x="0.0" y="106" width="414" height="430"/>
+                                        <rect key="frame" x="0.0" y="106" width="1080" height="422"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="chat_message_cell" id="YpP-xS-Pc0" customClass="ChatMessageTableViewCell" customModule="Odysee" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="28" width="414" height="54"/>
+                                                <rect key="frame" x="0.0" y="28" width="1080" height="54"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="YpP-xS-Pc0" id="Dpl-GH-Jwj">
-                                                    <rect key="frame" x="0.0" y="0.0" width="414" height="54"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="1080" height="54"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="6Gt-5s-q9m">
-                                                            <rect key="frame" x="0.0" y="0.0" width="414" height="54"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="1080" height="54"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W6P-tC-ZQy">
                                                                     <rect key="frame" x="16" y="2" width="100" height="50"/>
@@ -6042,7 +6042,7 @@
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gXR-KC-oh4">
-                                                                    <rect key="frame" x="122" y="2" width="276" height="0.0"/>
+                                                                    <rect key="frame" x="122" y="2" width="942" height="0.0"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -6070,7 +6070,7 @@
                                         </connections>
                                     </tableView>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Say something about this..." textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="klQ-fC-wqe">
-                                        <rect key="frame" x="8" y="540" width="398" height="34"/>
+                                        <rect key="frame" x="8" y="532" width="1064" height="34"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <textInputTraits key="textInputTraits"/>
                                         <connections>
@@ -6102,13 +6102,13 @@
                                 </constraints>
                             </view>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hSv-c7-vMI">
-                                <rect key="frame" x="0.0" y="284" width="414" height="578"/>
+                                <rect key="frame" x="0.0" y="240" width="1080" height="570"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="pCu-ZT-3Zh">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="538.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="1080" height="538.5"/>
                                         <subviews>
                                             <wkWebView hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oHk-Ea-M7X">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="0.0"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="1080" height="0.0"/>
                                                 <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" id="ZcC-zX-Z3O"/>
@@ -6119,10 +6119,10 @@
                                                 </wkWebViewConfiguration>
                                             </wkWebView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FTr-pZ-m9d" userLabel="Title Area">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="52.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="1080" height="52.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Z7I-sM-xB2">
-                                                        <rect key="frame" x="16" y="8" width="362" height="18"/>
+                                                        <rect key="frame" x="16" y="8" width="1028" height="18"/>
                                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -6140,7 +6140,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dqo-Nc-Y9a">
-                                                        <rect key="frame" x="378" y="0.0" width="36" height="52.5"/>
+                                                        <rect key="frame" x="1044" y="0.0" width="36" height="52.5"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chevron.down" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Nrm-Zv-xhd">
                                                                 <rect key="frame" x="9" y="13" width="18" height="8.5"/>
@@ -6180,7 +6180,7 @@
                                                 </connections>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="f4X-Fz-gj6" userLabel="File Actions Area">
-                                                <rect key="frame" x="0.0" y="60.5" width="414" height="48"/>
+                                                <rect key="frame" x="0.0" y="60.5" width="1080" height="48"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="FlY-aH-rqQ" userLabel="Fire Action">
                                                         <rect key="frame" x="0.0" y="0.0" width="64" height="48"/>
@@ -6211,7 +6211,7 @@
                                                         </connections>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="DZs-iw-eI8" userLabel="Slime Action">
-                                                        <rect key="frame" x="116.5" y="0.0" width="64" height="48"/>
+                                                        <rect key="frame" x="338.5" y="0.0" width="64" height="48"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="slime" translatesAutoresizingMaskIntoConstraints="NO" id="g4I-Z3-L5y">
                                                                 <rect key="frame" x="0.0" y="0.0" width="64" height="30"/>
@@ -6239,7 +6239,7 @@
                                                         </connections>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="im9-tm-NK6" userLabel="Share Action">
-                                                        <rect key="frame" x="233.5" y="0.0" width="64" height="48"/>
+                                                        <rect key="frame" x="677.5" y="0.0" width="64" height="48"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="square.and.arrow.up" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="ChE-t9-hxA">
                                                                 <rect key="frame" x="0.0" y="-1" width="64" height="31"/>
@@ -6267,7 +6267,7 @@
                                                         </connections>
                                                     </stackView>
                                                     <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="II9-pH-qUe" userLabel="Support Action">
-                                                        <rect key="frame" x="297.5" y="0.0" width="64" height="48"/>
+                                                        <rect key="frame" x="741.5" y="0.0" width="64" height="48"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="credits_icon" translatesAutoresizingMaskIntoConstraints="NO" id="kMz-av-0Nd">
                                                                 <rect key="frame" x="0.0" y="0.0" width="64" height="30"/>
@@ -6295,7 +6295,7 @@
                                                         </connections>
                                                     </stackView>
                                                     <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="xtl-IY-RdK" userLabel="Download Action">
-                                                        <rect key="frame" x="297.5" y="0.0" width="64" height="48"/>
+                                                        <rect key="frame" x="741.5" y="0.0" width="64" height="48"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="tray.and.arrow.down" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="xW2-ot-4of">
                                                                 <rect key="frame" x="0.0" y="-0.5" width="64" height="30.5"/>
@@ -6323,7 +6323,7 @@
                                                         </connections>
                                                     </stackView>
                                                     <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Jze-kH-Iqv" userLabel="Reload Action">
-                                                        <rect key="frame" x="297.5" y="0.0" width="64" height="48"/>
+                                                        <rect key="frame" x="741.5" y="0.0" width="64" height="48"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="arrow.clockwise" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="aIu-he-BLh">
                                                                 <rect key="frame" x="0.0" y="-1" width="64" height="30"/>
@@ -6351,7 +6351,7 @@
                                                         </connections>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="9pf-kL-184" userLabel="Report Action">
-                                                        <rect key="frame" x="350" y="0.0" width="64" height="48"/>
+                                                        <rect key="frame" x="1016" y="0.0" width="64" height="48"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="hux-q5-PnI">
                                                                 <rect key="frame" x="0.0" y="0.5" width="64" height="28.5"/>
@@ -6384,14 +6384,14 @@
                                                 </constraints>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="u9D-ac-xpG" userLabel="Divider">
-                                                <rect key="frame" x="0.0" y="116.5" width="414" height="1"/>
+                                                <rect key="frame" x="0.0" y="116.5" width="1080" height="1"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="nXI-nG-rLS"/>
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CSC-bu-5Wc" userLabel="Publisher Area">
-                                                <rect key="frame" x="0.0" y="125.5" width="414" height="56"/>
+                                                <rect key="frame" x="0.0" y="125.5" width="1080" height="56"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Cpe-cx-PuS">
                                                         <rect key="frame" x="16" y="8" width="40" height="40"/>
@@ -6401,16 +6401,16 @@
                                                         </constraints>
                                                     </imageView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Gnv-5D-mZo" userLabel="Publisher Labels">
-                                                        <rect key="frame" x="72" y="-22" width="218" height="100"/>
+                                                        <rect key="frame" x="72" y="-22" width="884" height="100"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wiE-Xh-DMm">
-                                                                <rect key="frame" x="0.0" y="0.0" width="218" height="50"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="884" height="50"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="186-dq-b5o">
-                                                                <rect key="frame" x="0.0" y="50" width="218" height="50"/>
+                                                                <rect key="frame" x="0.0" y="50" width="884" height="50"/>
                                                                 <gestureRecognizers/>
                                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="13"/>
                                                                 <color key="textColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
@@ -6425,7 +6425,7 @@
                                                         </constraints>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2BG-Yt-hXv" userLabel="Publisher Area Actions">
-                                                        <rect key="frame" x="313.5" y="16" width="100.5" height="24"/>
+                                                        <rect key="frame" x="979.5" y="16" width="100.5" height="24"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="UOZ-rp-sKU" userLabel="Follow / Unfollow View">
                                                                 <rect key="frame" x="0.0" y="0.0" width="100.5" height="24"/>
@@ -6499,17 +6499,17 @@
                                                 </connections>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0tH-f1-FDC" userLabel="Divider">
-                                                <rect key="frame" x="0.0" y="189.5" width="414" height="1"/>
+                                                <rect key="frame" x="0.0" y="189.5" width="1080" height="1"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="Fu8-G6-RWM"/>
                                                 </constraints>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="e2q-KI-gju">
-                                                <rect key="frame" x="0.0" y="198.5" width="414" height="0.0"/>
+                                                <rect key="frame" x="0.0" y="198.5" width="1080" height="0.0"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ay4-T6-Be4">
-                                                        <rect key="frame" x="0.0" y="0.0" width="414" height="0.0"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="1080" height="0.0"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -6517,29 +6517,29 @@
                                                 </subviews>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Bk-Nb-7Gz" userLabel="Divider">
-                                                <rect key="frame" x="0.0" y="206.5" width="414" height="1"/>
+                                                <rect key="frame" x="0.0" y="206.5" width="1080" height="1"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="5zR-aM-QFT"/>
                                                 </constraints>
                                             </view>
                                             <view autoresizesSubviews="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U8e-vA-alb" userLabel="Comments Area">
-                                                <rect key="frame" x="0.0" y="215.5" width="414" height="97"/>
+                                                <rect key="frame" x="0.0" y="215.5" width="1080" height="97"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Comments" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yba-Mi-nry" userLabel="Label">
-                                                        <rect key="frame" x="16" y="0.0" width="382" height="59"/>
+                                                        <rect key="frame" x="16" y="0.0" width="1048" height="59"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="There are no comments to display at this time. Be the first to post a comment!" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BaS-K8-e0h">
-                                                        <rect key="frame" x="16" y="68" width="350" height="29"/>
+                                                        <rect key="frame" x="16" y="82.5" width="1016" height="14.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="le9-MM-eZn">
-                                                        <rect key="frame" x="16" y="67" width="318" height="30"/>
+                                                        <rect key="frame" x="16" y="67" width="984" height="30"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Asy-44-nhW">
                                                                 <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
@@ -6549,7 +6549,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Zg-ZZ-Hpb">
-                                                                <rect key="frame" x="46" y="15" width="272" height="0.0"/>
+                                                                <rect key="frame" x="46" y="15" width="938" height="0.0"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -6566,7 +6566,7 @@
                                                         </constraints>
                                                     </view>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chevron.up.chevron.down" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="ito-DF-oZn">
-                                                        <rect key="frame" x="382" y="1.5" width="16" height="13"/>
+                                                        <rect key="frame" x="1048" y="1.5" width="16" height="13"/>
                                                         <color key="tintColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="16" id="CZo-1f-pWN"/>
@@ -6595,14 +6595,14 @@
                                                 </connections>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2X4-80-C8S" userLabel="Divider">
-                                                <rect key="frame" x="0.0" y="320.5" width="414" height="1"/>
+                                                <rect key="frame" x="0.0" y="320.5" width="1080" height="1"/>
                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="OXJ-fV-QJo"/>
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pq2-fF-5bU" userLabel="Related Content Area">
-                                                <rect key="frame" x="0.0" y="329.5" width="414" height="209"/>
+                                                <rect key="frame" x="0.0" y="329.5" width="1080" height="209"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Related Content" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Adh-uu-Xrm">
                                                         <rect key="frame" x="16" y="8" width="104.5" height="17"/>
@@ -6611,7 +6611,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="TeQ-fq-0Js" userLabel="Related Content List">
-                                                        <rect key="frame" x="0.0" y="33" width="414" height="160"/>
+                                                        <rect key="frame" x="0.0" y="33" width="1080" height="160"/>
                                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="160" id="cBi-wK-yrF"/>
@@ -6657,10 +6657,10 @@
                                 </constraints>
                             </scrollView>
                             <containerView hidden="YES" opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GiF-qv-hoI">
-                                <rect key="frame" x="0.0" y="284" width="414" height="578"/>
+                                <rect key="frame" x="0.0" y="240" width="1080" height="570"/>
                             </containerView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IzU-bX-6Of" userLabel="Dismiss File View">
-                                <rect key="frame" x="189" y="44" width="36" height="24"/>
+                                <rect key="frame" x="522" y="0.0" width="36" height="24"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chevron.down" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="ukC-pb-N9P">
                                         <rect key="frame" x="9" y="8" width="18" height="8.5"/>
@@ -6684,10 +6684,10 @@
                                 </connections>
                             </view>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VuG-8T-cXR" userLabel="Resolving Content View">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dfo-fR-6G5">
-                                        <rect key="frame" x="87" y="229" width="240" height="360"/>
+                                        <rect key="frame" x="420" y="225" width="240" height="360"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="spaceman_happy" translatesAutoresizingMaskIntoConstraints="NO" id="yFZ-CV-wIg">
                                                 <rect key="frame" x="20" y="56.5" width="200" height="240"/>
@@ -6719,7 +6719,7 @@
                                         </constraints>
                                     </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="close" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BZT-jG-hIL">
-                                        <rect key="frame" x="368" y="16" width="30" height="30"/>
+                                        <rect key="frame" x="1034" y="16" width="30" height="30"/>
                                         <connections>
                                             <action selector="closeTapped:" destination="Wx8-f6-Mvh" eventType="touchUpInside" id="cA0-My-jI4"/>
                                         </connections>
@@ -6734,11 +6734,11 @@
                                 </constraints>
                             </view>
                             <scrollView hidden="YES" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="71p-zu-OCP" customClass="ImageScrollView" customModule="ImageScrollView">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </scrollView>
                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="close" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ia6-r3-4DT">
-                                <rect key="frame" x="368" y="60" width="30" height="30"/>
+                                <rect key="frame" x="1034" y="16" width="30" height="30"/>
                                 <connections>
                                     <action selector="closeOtherContentTappedWith_sender:" destination="Wx8-f6-Mvh" eventType="touchUpInside" id="Cmj-Kb-NBm"/>
                                 </connections>
@@ -6949,14 +6949,14 @@
             <objects>
                 <viewController storyboardIdentifier="fr_vc" id="lpd-sn-lNG" customClass="FirstRunViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="lZf-AB-eSR">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vm3-JJ-xNe">
-                                <rect key="frame" x="0.0" y="44" width="414" height="754"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="746"/>
                             </containerView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gcX-2e-UJq">
-                                <rect key="frame" x="0.0" y="798" width="414" height="64"/>
+                                <rect key="frame" x="0.0" y="746" width="1080" height="64"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G0b-wY-woZ">
                                         <rect key="frame" x="16" y="18" width="30" height="28"/>
@@ -6967,7 +6967,7 @@
                                         </connections>
                                     </button>
                                     <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wUv-bo-aEk">
-                                        <rect key="frame" x="336" y="17" width="62" height="30"/>
+                                        <rect key="frame" x="1002" y="17" width="62" height="30"/>
                                         <state key="normal" title="Continue">
                                             <color key="titleColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                         </state>
@@ -6976,7 +6976,7 @@
                                         </connections>
                                     </button>
                                     <pageControl opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="Oke-Hz-pnK">
-                                        <rect key="frame" x="146" y="18" width="122.5" height="28"/>
+                                        <rect key="frame" x="479" y="18" width="122.5" height="28"/>
                                         <color key="pageIndicatorTintColor" systemColor="systemGray5Color"/>
                                         <color key="currentPageIndicatorTintColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                     </pageControl>
@@ -7022,27 +7022,27 @@
             <objects>
                 <viewController storyboardIdentifier="first_channel_vc" id="Zhc-4w-h8B" customClass="CreateChannelViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="uiE-WO-53W">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JE2-rM-9bJ" userLabel="Preload View">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="odysee_logo" translatesAutoresizingMaskIntoConstraints="NO" id="efl-bt-wWO">
-                                        <rect key="frame" x="127" y="128" width="160" height="160"/>
+                                        <rect key="frame" x="460" y="128" width="160" height="160"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="160" id="hdf-Nr-ytf"/>
                                             <constraint firstAttribute="height" constant="160" id="oHs-aX-uXZ"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Please wait while we check a few things..." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="69B-8a-Pia">
-                                        <rect key="frame" x="32" y="384" width="350" height="17"/>
+                                        <rect key="frame" x="32" y="384" width="1016" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="4qI-B3-NDM">
-                                        <rect key="frame" x="188.5" y="433" width="37" height="37"/>
+                                        <rect key="frame" x="521.5" y="433" width="37" height="37"/>
                                         <color key="color" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                     </activityIndicatorView>
                                 </subviews>
@@ -7059,41 +7059,41 @@
                                 </constraints>
                             </view>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ke0-lV-lo4">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ayo-L7-aj5">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="397"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="1080" height="380.5"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="odysee_logo" translatesAutoresizingMaskIntoConstraints="NO" id="AwA-ab-76Y">
-                                                <rect key="frame" x="167" y="32" width="80" height="80"/>
+                                                <rect key="frame" x="500" y="32" width="80" height="80"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="80" id="23i-TM-krH"/>
                                                     <constraint firstAttribute="height" constant="80" id="X0X-rr-nyL"/>
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Create a channel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fCy-64-CXX">
-                                                <rect key="frame" x="16" y="144" width="382" height="20.5"/>
+                                                <rect key="frame" x="16" y="144" width="1048" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your channel will be used for publishing and commenting. You can add more channels or remove this one later." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tjw-TM-aVD">
-                                                <rect key="frame" x="16" y="168.5" width="382" height="33.5"/>
+                                                <rect key="frame" x="16" y="168.5" width="1048" height="17"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your Odysee channel name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eVP-wF-iVe">
-                                                <rect key="frame" x="16" y="238" width="382" height="17"/>
+                                                <rect key="frame" x="16" y="221.5" width="1048" height="17"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OPj-Wj-0OJ" userLabel="Action Buttons">
-                                                <rect key="frame" x="16" y="345" width="382" height="44"/>
+                                                <rect key="frame" x="16" y="328.5" width="1048" height="44"/>
                                                 <subviews>
                                                     <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="tdT-AX-1iS">
-                                                        <rect key="frame" x="181" y="12" width="20" height="20"/>
+                                                        <rect key="frame" x="514" y="12" width="20" height="20"/>
                                                         <color key="color" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                                     </activityIndicatorView>
                                                 </subviews>
@@ -7105,7 +7105,7 @@
                                                 </constraints>
                                             </view>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="mychannel" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="V1u-7f-M8p">
-                                                <rect key="frame" x="16" y="263" width="382" height="34"/>
+                                                <rect key="frame" x="16" y="246.5" width="1048" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                                 <connections>
@@ -7177,27 +7177,27 @@
             <objects>
                 <viewController storyboardIdentifier="init_vc" id="TO2-4r-AEp" customClass="InitViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="unl-jb-x4V">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="launch_screen" translatesAutoresizingMaskIntoConstraints="NO" id="RXj-u9-0jQ">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                             </imageView>
                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="41E-JU-Zj0">
-                                <rect key="frame" x="188.5" y="429.5" width="37" height="37"/>
+                                <rect key="frame" x="521.5" y="386.5" width="37" height="37"/>
                                 <color key="color" red="0.89803921568627454" green="0.0" blue="0.32941176470588235" alpha="1" colorSpace="calibratedRGB"/>
                             </activityIndicatorView>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="koz-xy-DLz">
-                                <rect key="frame" x="32" y="380" width="350" height="136.5"/>
+                                <rect key="frame" x="32" y="353.5" width="1016" height="103"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Oops! The Odysee servers are unreachable at this time. Please check your Internet connection and try again." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="D0w-zV-D4B">
-                                        <rect key="frame" x="32" y="16" width="286" height="50.5"/>
+                                        <rect key="frame" x="32" y="16" width="952" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ljs-N9-n0x">
-                                        <rect key="frame" x="143" y="90.5" width="64" height="30"/>
+                                        <rect key="frame" x="476" y="57" width="64" height="30"/>
                                         <state key="normal" title="Try Again">
                                             <color key="titleColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                         </state>
@@ -7246,11 +7246,11 @@
             <objects>
                 <viewController storyboardIdentifier="search_vc" id="ZK9-XQ-4P5" customClass="SearchViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="SOB-mJ-Lek">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W1F-9s-sDA">
-                                <rect key="frame" x="0.0" y="44" width="414" height="48"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="48"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JiQ-UM-SeF" userLabel="Back Button">
                                         <rect key="frame" x="0.0" y="0.0" width="48" height="48"/>
@@ -7277,7 +7277,7 @@
                                         </connections>
                                     </view>
                                     <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="CLn-VR-8NN">
-                                        <rect key="frame" x="48" y="0.0" width="358" height="48"/>
+                                        <rect key="frame" x="48" y="0.0" width="1024" height="48"/>
                                         <textInputTraits key="textInputTraits"/>
                                         <connections>
                                             <outlet property="delegate" destination="ZK9-XQ-4P5" id="Ego-TV-Kzh"/>
@@ -7296,7 +7296,7 @@
                                 </constraints>
                             </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="vI9-g9-FJ7">
-                                <rect key="frame" x="0.0" y="92" width="414" height="770"/>
+                                <rect key="frame" x="0.0" y="48" width="1080" height="762"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <connections>
                                     <outlet property="dataSource" destination="ZK9-XQ-4P5" id="aWK-zs-2cJ"/>
@@ -7305,7 +7305,7 @@
                                 </connections>
                             </tableView>
                             <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="dgc-bS-LCm">
-                                <rect key="frame" x="107" y="319.5" width="200" height="257.5"/>
+                                <rect key="frame" x="440" y="276.5" width="200" height="257.5"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="spaceman_happy" translatesAutoresizingMaskIntoConstraints="NO" id="gGB-qs-nPs">
                                         <rect key="frame" x="0.0" y="0.0" width="200" height="200"/>
@@ -7323,7 +7323,7 @@
                                 </subviews>
                             </stackView>
                             <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="nRQ-3W-FNu">
-                                <rect key="frame" x="107" y="302.5" width="200" height="291"/>
+                                <rect key="frame" x="440" y="259.5" width="200" height="291"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="spaceman_sad" translatesAutoresizingMaskIntoConstraints="NO" id="RG4-fg-2sj">
                                         <rect key="frame" x="0.0" y="0.0" width="200" height="200"/>
@@ -7345,7 +7345,7 @@
                                 </connections>
                             </stackView>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XFM-dL-0Qf">
-                                <rect key="frame" x="175" y="416" width="64" height="64"/>
+                                <rect key="frame" x="508" y="373" width="64" height="64"/>
                                 <subviews>
                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="Vs8-pq-fXc">
                                         <rect key="frame" x="13.5" y="13.5" width="37" height="37"/>
@@ -7407,26 +7407,26 @@
             <objects>
                 <viewController storyboardIdentifier="comments_vc" id="mdv-2k-dtK" customClass="CommentsViewController" customModule="Odysee" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="wgd-dF-E28">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1080" height="810"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Comments" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vgp-99-NDn">
-                                <rect key="frame" x="16" y="128" width="382" height="19.5"/>
+                                <rect key="frame" x="16" y="84" width="1048" height="19.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="close" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="A3g-HN-7im">
-                                <rect key="frame" x="376" y="120" width="30" height="30"/>
+                                <rect key="frame" x="1042" y="76" width="30" height="30"/>
                                 <connections>
                                     <action selector="closeTapped:" destination="mdv-2k-dtK" eventType="touchUpInside" id="4vX-wZ-5w8"/>
                                 </connections>
                             </button>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Kj-jN-A6t">
-                                <rect key="frame" x="0.0" y="163.5" width="414" height="732.5"/>
+                                <rect key="frame" x="0.0" y="119.5" width="1080" height="690.5"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8ii-hy-A2Y">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="111.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="1080" height="111.5"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="U3v-g1-P45">
                                                 <rect key="frame" x="16" y="0.0" width="40" height="40"/>
@@ -7440,10 +7440,10 @@
                                                 </connections>
                                             </imageView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tpD-MK-VUz">
-                                                <rect key="frame" x="72" y="0.0" width="342" height="111.5"/>
+                                                <rect key="frame" x="72" y="0.0" width="1008" height="111.5"/>
                                                 <subviews>
                                                     <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Comment as" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YgH-58-g5n">
-                                                        <rect key="frame" x="0.0" y="0.0" width="342" height="14.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="1008" height="14.5"/>
                                                         <gestureRecognizers/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                         <nil key="textColor"/>
@@ -7453,7 +7453,7 @@
                                                         </connections>
                                                     </label>
                                                     <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Lgf-Jn-yN6" userLabel="Reply To Container View">
-                                                        <rect key="frame" x="0.0" y="18.5" width="342" height="4"/>
+                                                        <rect key="frame" x="0.0" y="18.5" width="1008" height="4"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="n5C-0N-3NS">
                                                                 <rect key="frame" x="2" y="0.0" width="3" height="128"/>
@@ -7463,13 +7463,13 @@
                                                                 </constraints>
                                                             </view>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fy7-hE-6JR">
-                                                                <rect key="frame" x="9" y="2" width="305" height="0.0"/>
+                                                                <rect key="frame" x="9" y="2" width="971" height="0.0"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                                 <color key="textColor" systemColor="systemGrayColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PNn-Lu-SNL" userLabel="Clear Reply To">
-                                                                <rect key="frame" x="318" y="-64" width="24" height="128"/>
+                                                                <rect key="frame" x="984" y="-64" width="24" height="128"/>
                                                                 <subviews>
                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="xmark" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Cdz-VX-WIM">
                                                                         <rect key="frame" x="4" y="-4" width="16" height="11.5"/>
@@ -7506,7 +7506,7 @@
                                                         <edgeInsets key="layoutMargins" top="4" left="8" bottom="0.0" right="4"/>
                                                     </view>
                                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Sp7-Sl-nD4">
-                                                        <rect key="frame" x="0.0" y="26.5" width="326" height="48"/>
+                                                        <rect key="frame" x="0.0" y="26.5" width="992" height="48"/>
                                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="48" id="kLD-sk-paq"/>
@@ -7519,7 +7519,7 @@
                                                         </connections>
                                                     </textView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0 / 2000" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7zu-JG-GFn">
-                                                        <rect key="frame" x="281.5" y="78.5" width="44.5" height="13.5"/>
+                                                        <rect key="frame" x="947.5" y="78.5" width="44.5" height="13.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -7565,7 +7565,7 @@
                                         </constraints>
                                     </view>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="cLO-Mr-vgT">
-                                        <rect key="frame" x="0.0" y="127.5" width="414" height="50"/>
+                                        <rect key="frame" x="0.0" y="127.5" width="1080" height="50"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="50" id="M0z-wE-VTn"/>
@@ -7573,10 +7573,10 @@
                                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="comment_cell" id="5Gy-Yo-ad1" customClass="CommentTableViewCell" customModule="Odysee" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="28" width="414" height="56.5"/>
+                                                <rect key="frame" x="0.0" y="28" width="1080" height="56.5"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="5Gy-Yo-ad1" id="y6z-Lm-Fdj">
-                                                    <rect key="frame" x="0.0" y="0.0" width="414" height="56.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="1080" height="56.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3Pc-Ox-7bE">
@@ -7587,16 +7587,16 @@
                                                             </constraints>
                                                         </imageView>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Tdm-6D-KDs" userLabel="Comment Details View">
-                                                            <rect key="frame" x="56" y="0.0" width="358" height="28.5"/>
+                                                            <rect key="frame" x="56" y="0.0" width="1024" height="28.5"/>
                                                             <subviews>
                                                                 <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tUo-nT-AQC">
-                                                                    <rect key="frame" x="16" y="8" width="326" height="0.0"/>
+                                                                    <rect key="frame" x="16" y="8" width="992" height="0.0"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                                     <color key="textColor" red="0.8980392157" green="0.0" blue="0.3294117647" alpha="1" colorSpace="calibratedRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i5q-Kz-cym">
-                                                                    <rect key="frame" x="16" y="12" width="326" height="0.0"/>
+                                                                    <rect key="frame" x="16" y="12" width="992" height="0.0"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -7743,13 +7743,13 @@
                                 </connections>
                             </scrollView>
                             <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="There are no comments to display at this time. Be the first to post a comment!" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GEL-6m-rWy">
-                                <rect key="frame" x="16" y="431.5" width="382" height="33.5"/>
+                                <rect key="frame" x="16" y="396.5" width="1048" height="17"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fKY-o2-fSU">
-                                <rect key="frame" x="175" y="416" width="64" height="64"/>
+                                <rect key="frame" x="508" y="373" width="64" height="64"/>
                                 <subviews>
                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="Ft5-js-EO7">
                                         <rect key="frame" x="13.5" y="13.5" width="37" height="37"/>
@@ -7765,10 +7765,10 @@
                                 </constraints>
                             </view>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FHK-uj-AcJ">
-                                <rect key="frame" x="0.0" y="44" width="414" height="68"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1080" height="68"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="It looks like you don't have any channels yet. Tap here to create a channel to join the conversation." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QLo-yB-Ozm">
-                                        <rect key="frame" x="16" y="16" width="382" height="36"/>
+                                        <rect key="frame" x="16" y="16" width="1048" height="36"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>

--- a/Odysee/Info.plist
+++ b/Odysee/Info.plist
@@ -41,10 +41,10 @@
 	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>Odysee requires access to your camera to take photos.</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Odysee requires access to your photo library.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Odysee requires access to your microphone to capture audio.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Odysee requires access to your photo library.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -78,6 +78,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIRequiresFullScreen</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
#6  Enable the build settings to allow iPad as a build target. There are still some issues with the layout (especially around keyboard support).
![Simulator Screen Shot - iPad Pro (11-inch) (2nd generation) - 2021-07-30 at 02 20 46](https://user-images.githubusercontent.com/1031501/127609688-da817df2-d02c-411d-967e-692cd9aae203.png)
