### PR TITLE
Added a lazyPlayer attribute to AppDelegate...

### DIFF
--- a/Odysee/AppDelegate.swift
+++ b/Odysee/AppDelegate.swift
@@ -28,6 +28,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     var currentFileViewController: FileViewController?
     var playerObserverAdded: Bool = false
     
+    // One-time only lazily activate the Audio Session when playing a file.
+    // This prevents the app from taking over the audio stream on launch.
+    lazy var lazyPlayer: AVPlayer? = {
+        do {
+            try AVAudioSession.sharedInstance().setActive(true, options: [])
+        } catch {
+            print("Lazy AVAudioSession activation failed! \(error)")
+        }
+        return self.player
+    }()
+    
     var mainController: MainViewController {
         return mainViewController as! MainViewController
     }
@@ -147,7 +158,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         commandCenter.playCommand.isEnabled = true
         commandCenter.playCommand.addTarget { [unowned self] event in
             if self.player != nil {
-                self.player!.play()
+                self.lazyPlayer!.play()
                 return .success
             }
             
@@ -156,7 +167,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         commandCenter.pauseCommand.isEnabled = true
         commandCenter.pauseCommand.addTarget { [unowned self] event in
             if self.player != nil {
-                self.player!.pause()
+                self.lazyPlayer!.pause()
                 return .success
             }
             

--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -111,7 +111,7 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
     
     var commentsDisabledChecked = false
     var commentsDisabled = false
-    var commentsViewPresented = false
+    var commentsViewPresented = false 
     var commentAsPicker: UIPickerView!
     var claim: Claim?
     var claimUrl: LbryUri?

--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -111,7 +111,7 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
     
     var commentsDisabledChecked = false
     var commentsDisabled = false
-    var commentsViewPresented = false  
+    var commentsViewPresented = false
     var commentAsPicker: UIPickerView!
     var claim: Claim?
     var claimUrl: LbryUri?
@@ -699,7 +699,7 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
         avpc.delegate = appDelegate.mainController
         if (!forceInit && appDelegate.player != nil && appDelegate.currentClaim != nil && appDelegate.currentClaim?.claimId == singleClaim.claimId) {
-            avpc.player = appDelegate.player
+            avpc.player = appDelegate.lazyPlayer
             playerConnected = true
             return
         }
@@ -714,7 +714,7 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
         appDelegate.player = AVPlayer(playerItem: playerItem)
 
         appDelegate.registerPlayerObserver()
-        avpc.player = appDelegate.player
+        avpc.player = appDelegate.lazyPlayer
         playerConnected = true
         playRequestTime = Int64(Date().timeIntervalSince1970 * 1000.0)
         
@@ -762,7 +762,7 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
     func connectPlayer() {
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
         if appDelegate.player != nil {
-            avpc.player = appDelegate.player
+            avpc.player = appDelegate.lazyPlayer
         }
         playerConnected = true
     }

--- a/Odysee/Controllers/Content/FileViewController.swift
+++ b/Odysee/Controllers/Content/FileViewController.swift
@@ -111,7 +111,7 @@ class FileViewController: UIViewController, UIGestureRecognizerDelegate, UINavig
     
     var commentsDisabledChecked = false
     var commentsDisabled = false
-    var commentsViewPresented = false 
+    var commentsViewPresented = false  
     var commentAsPicker: UIPickerView!
     var claim: Claim?
     var claimUrl: LbryUri?

--- a/Odysee/Controllers/MainViewController.swift
+++ b/Odysee/Controllers/MainViewController.swift
@@ -79,7 +79,6 @@ class MainViewController: UIViewController, AVPlayerViewControllerDelegate {
         do {
             // enable audio in silent mode
             try AVAudioSession.sharedInstance().setCategory(.playback)
-            try AVAudioSession.sharedInstance().setActive(true, options: [])
         } catch {
             // pass
         }


### PR DESCRIPTION
Added a lazyPlayer attribute to AppDelegate which delays activating AVAudioSession until something is played.

Not sure if the additional `lazyPlayer` object is the best way to do this or if a getter/setter on `player` would be better. Also not sure I hit all the required `appDelegate.player` instances. I left raw access to `player` in a bunch of conditionals.

This is my first attempt at wrapping my head around the repo, and I don't really know the best way to test (I just did a naive test on my iPhone), so thank you for your patience and feedback!

This PR should address issue #235 and issue #77.