### PR TITLE
Get test suite fully passing by fixing failing `MultistreamTests.testBasic` assertion

### DIFF
--- a/OdyseeTests/MultistreamTests.swift
+++ b/OdyseeTests/MultistreamTests.swift
@@ -25,8 +25,12 @@ class MultistreamTests: XCTestCase, StreamDelegate {
     @objc func testBasic() {
         let str1 = "Hello, world: "
         let stream1 = InputStream(data: str1.data(using: .utf8)!)
+        stream1.open()
+
         let str2 = "my name is Odysee! "
         let stream2 = InputStream(data: str2.data(using: .utf8)!)
+        stream2.open()
+
         let fm = FileManager.default
         let filePath = fm.temporaryDirectory.appendingPathComponent("ms_test.dat").path
         if !fm.fileExists(atPath: filePath) {
@@ -34,6 +38,8 @@ class MultistreamTests: XCTestCase, StreamDelegate {
             fm.createFile(atPath: filePath, contents: str3.data(using: .utf8), attributes: nil)
         }
         let stream3 = InputStream(fileAtPath: filePath)!
+        stream3.open()
+
         let ms = Multistream(streams: [stream1, stream2, stream3])
         ms.schedule(in: RunLoop.current, forMode: .default)
         ms.delegate = self


### PR DESCRIPTION
Results from test suite on `master`:

![Screen Shot 2021-09-22 at 9 11 29 PM](https://user-images.githubusercontent.com/1238684/134467700-e80e0caf-17a8-4274-82e0-39021877a806.png)

Results on this branch after the fix:

![Screen Shot 2021-09-22 at 9 09 39 PM](https://user-images.githubusercontent.com/1238684/134467680-3a5cbbd6-9d78-4c81-9bc2-84cb10ea85c4.png)